### PR TITLE
Add more validators

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -12,34 +12,16 @@ Object.defineProperty(exports, 'all', {
     return _compose.all;
   }
 });
+Object.defineProperty(exports, 'allWhileOK', {
+  enumerable: true,
+  get: function get() {
+    return _compose.allWhileOK;
+  }
+});
 Object.defineProperty(exports, 'some', {
   enumerable: true,
   get: function get() {
     return _compose.some;
-  }
-});
-Object.defineProperty(exports, 'fromObjectSchema', {
-  enumerable: true,
-  get: function get() {
-    return _compose.fromObjectSchema;
-  }
-});
-Object.defineProperty(exports, 'fromArraySchema', {
-  enumerable: true,
-  get: function get() {
-    return _compose.fromArraySchema;
-  }
-});
-Object.defineProperty(exports, 'objectValidator', {
-  enumerable: true,
-  get: function get() {
-    return _compose.objectValidator;
-  }
-});
-Object.defineProperty(exports, 'arrayValidator', {
-  enumerable: true,
-  get: function get() {
-    return _compose.arrayValidator;
   }
 });
 
@@ -81,9 +63,180 @@ Object.defineProperty(exports, 'mapErrors', {
     return _result.mapErrors;
   }
 });
+Object.defineProperty(exports, 'prefixErrors', {
+  enumerable: true,
+  get: function get() {
+    return _result.prefixErrors;
+  }
+});
 Object.defineProperty(exports, 'flattenResults', {
   enumerable: true,
   get: function get() {
     return _result.flattenResults;
+  }
+});
+Object.defineProperty(exports, 'getErrors', {
+  enumerable: true,
+  get: function get() {
+    return _result.getErrors;
+  }
+});
+
+var _schema = require('./lib/schema');
+
+Object.defineProperty(exports, 'validateAsObjectSchema', {
+  enumerable: true,
+  get: function get() {
+    return _schema.validateAsObjectSchema;
+  }
+});
+Object.defineProperty(exports, 'validateAsArraySchema', {
+  enumerable: true,
+  get: function get() {
+    return _schema.validateAsArraySchema;
+  }
+});
+Object.defineProperty(exports, 'fromObjectSchema', {
+  enumerable: true,
+  get: function get() {
+    return _schema.fromObjectSchema;
+  }
+});
+Object.defineProperty(exports, 'fromObjectSchemaStrict', {
+  enumerable: true,
+  get: function get() {
+    return _schema.fromObjectSchemaStrict;
+  }
+});
+Object.defineProperty(exports, 'fromArraySchema', {
+  enumerable: true,
+  get: function get() {
+    return _schema.fromArraySchema;
+  }
+});
+Object.defineProperty(exports, 'objectValidator', {
+  enumerable: true,
+  get: function get() {
+    return _schema.objectValidator;
+  }
+});
+Object.defineProperty(exports, 'arrayValidator', {
+  enumerable: true,
+  get: function get() {
+    return _schema.arrayValidator;
+  }
+});
+
+var _typecheck = require('./lib/typecheck');
+
+Object.defineProperty(exports, 'isISOString', {
+  enumerable: true,
+  get: function get() {
+    return _typecheck.isISOString;
+  }
+});
+Object.defineProperty(exports, 'isDate', {
+  enumerable: true,
+  get: function get() {
+    return _typecheck.isDate;
+  }
+});
+Object.defineProperty(exports, 'isObject', {
+  enumerable: true,
+  get: function get() {
+    return _typecheck.isObject;
+  }
+});
+Object.defineProperty(exports, 'isArray', {
+  enumerable: true,
+  get: function get() {
+    return _typecheck.isArray;
+  }
+});
+Object.defineProperty(exports, 'isType', {
+  enumerable: true,
+  get: function get() {
+    return _typecheck.isType;
+  }
+});
+
+var _validators = require('./lib/validators');
+
+Object.defineProperty(exports, 'alwaysErr', {
+  enumerable: true,
+  get: function get() {
+    return _validators.alwaysErr;
+  }
+});
+Object.defineProperty(exports, 'alwaysOK', {
+  enumerable: true,
+  get: function get() {
+    return _validators.alwaysOK;
+  }
+});
+Object.defineProperty(exports, 'fromPredicate', {
+  enumerable: true,
+  get: function get() {
+    return _validators.fromPredicate;
+  }
+});
+Object.defineProperty(exports, 'validateIsType', {
+  enumerable: true,
+  get: function get() {
+    return _validators.validateIsType;
+  }
+});
+Object.defineProperty(exports, 'validateIsIn', {
+  enumerable: true,
+  get: function get() {
+    return _validators.validateIsIn;
+  }
+});
+Object.defineProperty(exports, 'validateIsObject', {
+  enumerable: true,
+  get: function get() {
+    return _validators.validateIsObject;
+  }
+});
+Object.defineProperty(exports, 'validateObjHasKey', {
+  enumerable: true,
+  get: function get() {
+    return _validators.validateObjHasKey;
+  }
+});
+Object.defineProperty(exports, 'validateObjPropHasType', {
+  enumerable: true,
+  get: function get() {
+    return _validators.validateObjPropHasType;
+  }
+});
+Object.defineProperty(exports, 'validateObjPropPasses', {
+  enumerable: true,
+  get: function get() {
+    return _validators.validateObjPropPasses;
+  }
+});
+Object.defineProperty(exports, 'validateObjOnlyHasKeys', {
+  enumerable: true,
+  get: function get() {
+    return _validators.validateObjOnlyHasKeys;
+  }
+});
+Object.defineProperty(exports, 'validateIsArray', {
+  enumerable: true,
+  get: function get() {
+    return _validators.validateIsArray;
+  }
+});
+Object.defineProperty(exports, 'validateArrayItemsHaveType', {
+  enumerable: true,
+  get: function get() {
+    return _validators.validateArrayItemsHaveType;
+  }
+});
+Object.defineProperty(exports, 'validateArrayItemsPass', {
+  enumerable: true,
+  get: function get() {
+    return _validators.validateArrayItemsPass;
   }
 });

--- a/dist/lib/result.js
+++ b/dist/lib/result.js
@@ -46,6 +46,13 @@ var mapErrors = exports.mapErrors = function mapErrors(f) {
   };
 };
 
+// Prefix every error in a Result with the given string
+var prefixErrors = exports.prefixErrors = function prefixErrors(prefix) {
+  return mapErrors(function (e) {
+    return "" + prefix + e;
+  });
+};
+
 // Flatten an array of Results into a single Result
 var flattenResults = exports.flattenResults = function flattenResults(results) {
   return results.reduce(function (acc, r) {

--- a/dist/lib/typecheck.js
+++ b/dist/lib/typecheck.js
@@ -27,8 +27,8 @@ var isDate = exports.isDate = function isDate(val) {
 /**
  * Is the parameter a non-array, non-date object?
  */
-var isObject = exports.isObject = function isObject(data) {
-  return data && (typeof data === 'undefined' ? 'undefined' : _typeof(data)) === 'object' && !isArray(data) && !isDate(data);
+var isObject = exports.isObject = function isObject(val) {
+  return val && (typeof val === 'undefined' ? 'undefined' : _typeof(val)) === 'object' && !isArray(val) && !isDate(val);
 };
 
 /**
@@ -36,6 +36,13 @@ var isObject = exports.isObject = function isObject(data) {
  */
 var isArray = exports.isArray = function isArray(arr) {
   return Array.isArray(arr);
+};
+
+/**
+ * Is the parameter null?
+ */
+var isNull = exports.isNull = function isNull(val) {
+  return val === null;
 };
 
 /**
@@ -50,6 +57,8 @@ var isType = exports.isType = function isType(type) {
         return isDate(val);
       case 'object':
         return isObject(val);
+      case 'null':
+        return isNull(val);
       default:
         return (typeof val === 'undefined' ? 'undefined' : _typeof(val)) === type;
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@times/data-validator",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Simple, composable data validator for JavaScript",
   "main": "dist/index.js",
   "dependencies": {},
@@ -23,11 +23,7 @@
     "build": "babel src -d dist",
     "prepublish": "npm run build"
   },
-  "keywords": [
-    "schema",
-    "validator",
-    "validation"
-  ],
+  "keywords": ["schema", "validator", "validation"],
   "contributors": [
     {
       "name": "Elliot Davies",
@@ -51,13 +47,8 @@
   },
   "homepage": "https://github.com/times/data-validator#readme",
   "nyc": {
-    "require": [
-      "babel-register"
-    ],
-    "reporter": [
-      "lcov",
-      "text"
-    ],
+    "require": ["babel-register"],
+    "reporter": ["lcov", "text"],
     "sourceMap": false,
     "instrument": false
   }

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ export {
   isErr,
   toResult,
   mapErrors,
+  prefixErrors,
   flattenResults,
   getErrors,
 } from './lib/result';
@@ -30,6 +31,11 @@ export {
 } from './lib/typecheck';
 
 export {
+  alwaysErr,
+  alwaysOK,
+  fromPredicate,
+  validateIsType,
+  validateIsIn,
   validateIsObject,
   validateObjHasKey,
   validateObjPropHasType,
@@ -38,6 +44,4 @@ export {
   validateIsArray,
   validateArrayItemsHaveType,
   validateArrayItemsPass,
-  alwaysErr,
-  alwaysOK,
 } from './lib/validators';

--- a/src/lib/result.js
+++ b/src/lib/result.js
@@ -37,6 +37,11 @@ export const toResult: ToResult = errs =>
 type MapErrors = ((string) => string) => Result => Result;
 export const mapErrors: MapErrors = f => r => toResult(r.errors.map(f));
 
+// Prefix every error in a Result with the given string
+type PrefixErrors = string => Result => Result;
+export const prefixErrors: PrefixErrors = prefix =>
+  mapErrors(e => `${prefix}${e}`);
+
 // Flatten an array of Results into a single Result
 type FlattenResults = (Array<Result>) => Result;
 export const flattenResults: FlattenResults = results =>

--- a/src/lib/typecheck.js
+++ b/src/lib/typecheck.js
@@ -22,14 +22,20 @@ export const isDate: IsDate = val => val instanceof Date || isISOString(val);
  * Is the parameter a non-array, non-date object?
  */
 type IsObject = any => boolean;
-export const isObject: IsObject = data =>
-  data && typeof data === 'object' && !isArray(data) && !isDate(data);
+export const isObject: IsObject = val =>
+  val && typeof val === 'object' && !isArray(val) && !isDate(val);
 
 /**
  * Is the parameter an array?
  */
 type IsArray = any => boolean;
 export const isArray: IsArray = arr => Array.isArray(arr);
+
+/**
+ * Is the parameter null?
+ */
+type IsNull = any => boolean;
+export const isNull: IsNull = val => val === null;
 
 /**
  * Does the given value match the given type?
@@ -43,6 +49,8 @@ export const isType: IsType = type => val => {
       return isDate(val);
     case 'object':
       return isObject(val);
+    case 'null':
+      return isNull(val);
     default:
       return typeof val === type;
   }

--- a/src/lib/validators.js
+++ b/src/lib/validators.js
@@ -1,7 +1,7 @@
 // @flow
 
-import { isObject, isArray, isType } from './typecheck';
-import { ok, err, toResult, mapErrors, flattenResults } from './result';
+import { isType } from './typecheck';
+import { ok, err, toResult, prefixErrors, flattenResults } from './result';
 import type { Result, Errors } from './result';
 
 /**
@@ -73,7 +73,7 @@ export const validateObjPropHasType: ValidateObjPropHasType = type => key => obj
 type ValidateObjPropPasses = Validator => string => Validator;
 export const validateObjPropPasses: ValidateObjPropPasses = v => key => obj => {
   if (!obj.hasOwnProperty(key)) return ok();
-  return mapErrors(e => `At field "${key}": ${e}`)(v(obj[key]));
+  return prefixErrors(`At field "${key}": `)(v(obj[key]));
 };
 
 /**
@@ -98,7 +98,7 @@ export const validateIsArray: ValidateIsArray = validateIsType('array');
  */
 type ValidateArrayItemsHaveType = string => Validator;
 export const validateArrayItemsHaveType: ValidateArrayItemsHaveType = type => arr =>
-  mapErrors(e => `Item ${e}`)(flattenResults(arr.map(validateIsType(type))));
+  prefixErrors(`Item `)(flattenResults(arr.map(validateIsType(type))));
 
 /**
  * Does each array item pass the given validator?
@@ -106,5 +106,5 @@ export const validateArrayItemsHaveType: ValidateArrayItemsHaveType = type => ar
 type ValidateArrayItemsPass = Validator => Validator;
 export const validateArrayItemsPass: ValidateArrayItemsPass = v => arr =>
   flattenResults(
-    arr.map(v).map((res, i) => mapErrors(e => `At item ${i}: ${e}`)(res))
+    arr.map(v).map((res, i) => prefixErrors(`At item ${i}: `)(res))
   );

--- a/src/lib/validators.js
+++ b/src/lib/validators.js
@@ -41,6 +41,16 @@ export const validateIsType: ValidateIsType = type =>
   );
 
 /**
+ * Is the given value in the given array of values?
+ */
+type ValidateIsIn = (Array<*>) => Validator;
+export const validateIsIn: ValidateIsIn = values =>
+  fromPredicate(
+    val => values.includes(val),
+    val => `Value must be one of ${values.join(', ')} (got "${val}")`
+  );
+
+/**
  * Is the given data an object?
  */
 type ValidateIsObject = Validator;

--- a/src/lib/validators.js
+++ b/src/lib/validators.js
@@ -12,6 +12,27 @@ export type Data = any;
 export type Validator = Data => Result;
 
 /**
+ * Always an error
+ */
+type AlwaysErr = Errors => Validator;
+export const alwaysErr: AlwaysErr = errs => () => err(errs);
+
+/**
+ * Always OK
+ */
+type AlwaysOK = () => Validator;
+export const alwaysOK: AlwaysOK = () => () => ok();
+
+/**
+ * Construct a validator from a boolean function
+ */
+type FromBooleanFunction = ((Data) => boolean, (Data) => string) => Validator;
+export const fromBooleanFunction: FromBooleanFunction = (
+  test,
+  toErrMsg
+) => data => (test(data) ? ok() : err([toErrMsg(data)]));
+
+/**
  * Is the given data an object?
  */
 type ValidateIsObject = Validator;
@@ -82,15 +103,3 @@ export const validateArrayItemsPass: ValidateArrayItemsPass = v => arr =>
   flattenResults(
     arr.map(v).map((res, i) => mapErrors(e => `At item ${i}: ${e}`)(res))
   );
-
-/**
- * Always an error
- */
-type AlwaysErr = Errors => Validator;
-export const alwaysErr: AlwaysErr = errs => () => err(errs);
-
-/**
- * Always OK
- */
-type AlwaysOK = () => Validator;
-export const alwaysOK: AlwaysOK = () => () => ok();

--- a/test/compose.spec.js
+++ b/test/compose.spec.js
@@ -42,7 +42,7 @@ describe('compose', () => {
       const validate = all([validateIsObject, validateObjHasKey('field1')]);
 
       expect(validate('not an object').errors).to.deep.equal([
-        `Data was not an object`,
+        `"not an object" failed to typecheck (expected object)`,
         `Missing required field \"field1\"`,
       ]);
 
@@ -106,7 +106,7 @@ describe('compose', () => {
       ]);
 
       expect(validate('not an object').errors).to.deep.equal([
-        `Data was not an object`,
+        `"not an object" failed to typecheck (expected object)`,
       ]);
 
       expect(validate({}).errors).to.deep.equal([
@@ -150,8 +150,8 @@ describe('compose', () => {
     it('returns errors from all the validators if it fails', () => {
       const validate = some([validateIsObject, validateIsArray]);
       expect(validate(123).errors).to.deep.equal([
-        'Data was not an object',
-        'Data was not an array',
+        '"123" failed to typecheck (expected object)',
+        '"123" failed to typecheck (expected array)',
       ]);
     });
 

--- a/test/result.spec.js
+++ b/test/result.spec.js
@@ -6,6 +6,7 @@ import {
   isErr,
   toResult,
   mapErrors,
+  prefixErrors,
   flattenResults,
   getErrors,
 } from '../src/lib/result';
@@ -81,6 +82,22 @@ describe('result', () => {
       const res = err(['a', 'b', 'c']);
 
       expect(map(res).errors).to.deep.equal(['1. a', '2. b', '3. c']);
+    });
+  });
+
+  describe('#prefixErrors()', () => {
+    it('should not change the type of the Result', () => {
+      const map = prefixErrors('something');
+
+      expect(isOK(map(ok())));
+      expect(isErr(map(err())));
+    });
+
+    it('should prefix each error in a Result', () => {
+      const map = prefixErrors('P: ');
+      const res = err(['a', 'b', 'c']);
+
+      expect(map(res).errors).to.deep.equal(['P: a', 'P: b', 'P: c']);
     });
   });
 

--- a/test/schema.spec.js
+++ b/test/schema.spec.js
@@ -112,7 +112,7 @@ describe('schema', () => {
       expect(isErr(validate({ field2: 1234 }))).to.be.true;
 
       expect(validate({ field2: 1234 }).errors).to.deep.equal([
-        'Schema error: Data was not an object',
+        'Schema error: "test-1234" failed to typecheck (expected object)',
       ]);
     });
 
@@ -244,7 +244,7 @@ describe('schema', () => {
       });
       const validate1 = all(vs1);
       expect(validate1({ field1: 12345 }).errors).to.deep.equal([
-        `At field "field1": Data was not an object`,
+        `At field "field1": "12345" failed to typecheck (expected object)`,
       ]);
 
       // One level deeper
@@ -255,7 +255,7 @@ describe('schema', () => {
       });
       const validate2 = all(vs2);
       expect(validate2({ field2: { field1: 12345 } }).errors).to.deep.equal([
-        `At field "field2": At field "field1": Data was not an object`,
+        `At field "field2": At field "field1": "12345" failed to typecheck (expected object)`,
       ]);
     });
 
@@ -396,7 +396,7 @@ describe('schema', () => {
       });
       const validate1 = all(vs1);
       expect(validate1([{}, 1, {}]).errors).to.deep.equal([
-        `At item 1: Data was not an object`,
+        `At item 1: "1" failed to typecheck (expected object)`,
       ]);
 
       // One level deeper
@@ -405,7 +405,7 @@ describe('schema', () => {
       });
       const validate2 = all(vs2);
       expect(validate2([[{}], [1]]).errors).to.deep.equal([
-        `At item 1: At item 0: Data was not an object`,
+        `At item 1: At item 0: "1" failed to typecheck (expected object)`,
       ]);
     });
 

--- a/test/typecheck.spec.js
+++ b/test/typecheck.spec.js
@@ -94,6 +94,9 @@ describe('typecheck', () => {
       expect(isType('number')('1')).to.be.false;
       expect(isType('object')(new Date())).to.be.false;
       expect(isType('number')(new Date())).to.be.false;
+      expect(isType('boolean')(0)).to.be.false;
+      expect(isType(null)(false)).to.be.false;
+      expect(isType(undefined)(null)).to.be.false;
 
       const f = () => {};
       expect(isType('object')(f)).to.be.false;
@@ -105,6 +108,10 @@ describe('typecheck', () => {
       expect(isType('object')({})).to.be.true;
       expect(isType('string')('sss')).to.be.true;
       expect(isType('date')(new Date())).to.be.true;
+      expect(isType('boolean')(true)).to.be.true;
+      expect(isType('boolean')(false)).to.be.true;
+      expect(isType('null')(null)).to.be.true;
+      expect(isType('undefined')(undefined)).to.be.true;
 
       const f = () => {};
       expect(isType('function')(f)).to.be.true;

--- a/test/validators.spec.js
+++ b/test/validators.spec.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
-import { isOK, isErr, ok, err } from '../src/lib/result';
+import { isOK, isErr, ok, err, getErrors } from '../src/lib/result';
 import {
+  fromBooleanFunction,
   validateIsObject,
   validateObjHasKey,
   validateObjPropHasType,
@@ -14,6 +15,55 @@ import {
 } from '../src/lib/validators';
 
 describe('validators', () => {
+  describe('#alwaysErr()', () => {
+    it('should return a validator that always errors', () => {
+      const validate = alwaysErr(['Error one', 'Error two']);
+
+      expect(isErr(validate())).to.be.true;
+      expect(isErr(validate({ test: '1234' }))).to.be.true;
+      expect(isErr(validate([1, 2, 3]))).to.be.true;
+    });
+
+    it('should return the errors passed into it', () => {
+      const errors = ['Error one', 'Error two'];
+
+      const validate = alwaysErr(errors);
+
+      expect(validate().errors).to.deep.equal(errors);
+    });
+  });
+
+  describe('#alwaysOK()', () => {
+    it('should return a validator that always succeeds', () => {
+      const validate = alwaysOK();
+
+      expect(isOK(validate())).to.be.true;
+      expect(isOK(validate({ test: '1234' }))).to.be.true;
+      expect(isOK(validate([1, 2, 3]))).to.be.true;
+    });
+  });
+
+  describe('#fromBooleanFunction()', () => {
+    it('constructs a validator that returns an OK if the test function passes', () => {
+      const validate = fromBooleanFunction(
+        x => x === 10,
+        x => `${x} was not 10`
+      );
+
+      expect(isOK(validate(10))).to.be.true;
+      expect(isErr(validate(15))).to.be.true;
+    });
+
+    it('constructs a validator that returns an Err using the given error function if the test function fails', () => {
+      const validate = fromBooleanFunction(
+        x => x === 10,
+        x => `${x} was not 10`
+      );
+
+      expect(getErrors(validate(15))).to.deep.equal(['15 was not 10']);
+    });
+  });
+
   describe('#validateIsObject()', () => {
     it('should return an Err when the given data is not an object', () => {
       const res = validateIsObject('string');
@@ -222,34 +272,6 @@ describe('validators', () => {
     it('should return OK if all the items pass the given validator', () => {
       const res = validate([4, 5, 6]);
       expect(isOK(res)).to.be.true;
-    });
-  });
-
-  describe('#alwaysErr()', () => {
-    it('should return a validator that always errors', () => {
-      const validate = alwaysErr(['Error one', 'Error two']);
-
-      expect(isErr(validate())).to.be.true;
-      expect(isErr(validate({ test: '1234' }))).to.be.true;
-      expect(isErr(validate([1, 2, 3]))).to.be.true;
-    });
-
-    it('should return the errors passed into it', () => {
-      const errors = ['Error one', 'Error two'];
-
-      const validate = alwaysErr(errors);
-
-      expect(validate().errors).to.deep.equal(errors);
-    });
-  });
-
-  describe('#alwaysOK()', () => {
-    it('should return a validator that always succeeds', () => {
-      const validate = alwaysOK();
-
-      expect(isOK(validate())).to.be.true;
-      expect(isOK(validate({ test: '1234' }))).to.be.true;
-      expect(isOK(validate([1, 2, 3]))).to.be.true;
     });
   });
 });

--- a/test/validators.spec.js
+++ b/test/validators.spec.js
@@ -5,6 +5,7 @@ import {
   alwaysOK,
   fromPredicate,
   validateIsType,
+  validateIsIn,
   validateIsObject,
   validateObjHasKey,
   validateObjPropHasType,
@@ -77,6 +78,26 @@ describe('validators', () => {
       expect(isOK(validateIsType('boolean')(false))).to.be.true;
       expect(isOK(validateIsType('number')(123))).to.be.true;
       expect(isOK(validateIsType('string')('sss'))).to.be.true;
+    });
+  });
+
+  describe('#validateIsIn()', () => {
+    it('should return an Err when the value is not in the provided array', () => {
+      const validate = validateIsIn([1, 2, 3, 4, 5]);
+      expect(isErr(validate(-5))).to.be.true;
+      expect(isErr(validate(0))).to.be.true;
+      expect(isErr(validate('1'))).to.be.true;
+      expect(isErr(validate(6))).to.be.true;
+
+      expect(getErrors(validate(6))).to.deep.equal([
+        `Value must be one of 1, 2, 3, 4, 5 (got "6")`,
+      ]);
+    });
+
+    it('should return OK when the value is in the provided array', () => {
+      const validate = validateIsIn([1, 2, 3, 4, 5]);
+      expect(isOK(validate(1))).to.be.true;
+      expect(isOK(validate(5))).to.be.true;
     });
   });
 

--- a/test/validators.spec.js
+++ b/test/validators.spec.js
@@ -1,7 +1,10 @@
 import { expect } from 'chai';
 import { isOK, isErr, ok, err, getErrors } from '../src/lib/result';
 import {
-  fromBooleanFunction,
+  alwaysErr,
+  alwaysOK,
+  fromPredicate,
+  validateIsType,
   validateIsObject,
   validateObjHasKey,
   validateObjPropHasType,
@@ -10,8 +13,6 @@ import {
   validateIsArray,
   validateArrayItemsHaveType,
   validateArrayItemsPass,
-  alwaysErr,
-  alwaysOK,
 } from '../src/lib/validators';
 
 describe('validators', () => {
@@ -29,7 +30,7 @@ describe('validators', () => {
 
       const validate = alwaysErr(errors);
 
-      expect(validate().errors).to.deep.equal(errors);
+      expect(getErrors(validate())).to.deep.equal(errors);
     });
   });
 
@@ -43,24 +44,39 @@ describe('validators', () => {
     });
   });
 
-  describe('#fromBooleanFunction()', () => {
+  describe('#fromPredicate()', () => {
     it('constructs a validator that returns an OK if the test function passes', () => {
-      const validate = fromBooleanFunction(
-        x => x === 10,
-        x => `${x} was not 10`
-      );
+      const validate = fromPredicate(x => x === 10, x => `${x} was not 10`);
 
       expect(isOK(validate(10))).to.be.true;
       expect(isErr(validate(15))).to.be.true;
     });
 
     it('constructs a validator that returns an Err using the given error function if the test function fails', () => {
-      const validate = fromBooleanFunction(
-        x => x === 10,
-        x => `${x} was not 10`
-      );
+      const validate = fromPredicate(x => x === 10, x => `${x} was not 10`);
 
       expect(getErrors(validate(15))).to.deep.equal(['15 was not 10']);
+    });
+  });
+
+  describe('#validateIsType()', () => {
+    it('should return an Err when the given data is not of the given type', () => {
+      const validate = validateIsType('string');
+
+      const res = validate(123);
+      expect(isErr(res)).to.be.true;
+      expect(getErrors(res)).to.deep.equal([
+        `"123" failed to typecheck (expected string)`,
+      ]);
+
+      expect(isErr(validateIsType('null')(true))).to.be.true;
+      expect(isErr(validateIsType('number')('123'))).to.be.true;
+    });
+
+    it('should return OK when the given data is of the correct type', () => {
+      expect(isOK(validateIsType('boolean')(false))).to.be.true;
+      expect(isOK(validateIsType('number')(123))).to.be.true;
+      expect(isOK(validateIsType('string')('sss'))).to.be.true;
     });
   });
 
@@ -68,7 +84,9 @@ describe('validators', () => {
     it('should return an Err when the given data is not an object', () => {
       const res = validateIsObject('string');
       expect(isErr(res)).to.be.true;
-      expect(res.errors).to.deep.equal([`Data was not an object`]);
+      expect(getErrors(res)).to.deep.equal([
+        `"string" failed to typecheck (expected object)`,
+      ]);
 
       expect(isErr(validateIsObject(1))).to.be.true;
       expect(isErr(validateIsObject([]))).to.be.true;
@@ -78,7 +96,7 @@ describe('validators', () => {
     it('should return an OK when the given data is an object', () => {
       const res = validateIsObject({});
       expect(isOK(res)).to.be.true;
-      expect(res.errors).to.deep.equal([]);
+      expect(getErrors(res)).to.deep.equal([]);
 
       expect(isOK(validateIsObject({ a: 1, b: 2 }))).to.be.true;
     });
@@ -90,7 +108,7 @@ describe('validators', () => {
         field2: 'present and correct',
       });
       expect(isErr(res)).to.be.true;
-      expect(res.errors).to.deep.equal([`Missing required field "field1"`]);
+      expect(getErrors(res)).to.deep.equal([`Missing required field "field1"`]);
     });
 
     it('should return an OK when the given data has all the required fields', () => {
@@ -98,7 +116,7 @@ describe('validators', () => {
         field1: 'here',
       });
       expect(isOK(res1)).to.be.true;
-      expect(res1.errors).to.deep.equal([]);
+      expect(getErrors(res1)).to.deep.equal([]);
     });
   });
 
@@ -108,7 +126,7 @@ describe('validators', () => {
         field1: 123,
       });
       expect(isErr(res1)).to.be.true;
-      expect(res1.errors).to.deep.equal([
+      expect(getErrors(res1)).to.deep.equal([
         `Field "field1" failed to typecheck (expected string)`,
       ]);
 
@@ -117,7 +135,7 @@ describe('validators', () => {
         field2: 'not a number',
       });
       expect(isErr(res2)).to.be.true;
-      expect(res2.errors).to.deep.equal([
+      expect(getErrors(res2)).to.deep.equal([
         `Field "field2" failed to typecheck (expected number)`,
       ]);
     });
@@ -128,7 +146,7 @@ describe('validators', () => {
         field2: 12345,
       });
       expect(isOK(res)).to.be.true;
-      expect(res.errors).to.deep.equal([]);
+      expect(getErrors(res)).to.deep.equal([]);
     });
 
     it("should return an OK for fields that don't specify a type", () => {
@@ -150,8 +168,8 @@ describe('validators', () => {
         field1: 123,
       });
       expect(isErr(res1)).to.be.true;
-      expect(res1.errors).to.deep.equal([
-        `At field "field1": Data was not an array`,
+      expect(getErrors(res1)).to.deep.equal([
+        `At field "field1": "123" failed to typecheck (expected array)`,
       ]);
 
       const res2 = validateObjPropPasses(validateIsArray)('field1')({
@@ -182,7 +200,7 @@ describe('validators', () => {
         field3: 'should not be here',
       });
       expect(isErr(res1)).to.be.true;
-      expect(res1.errors).to.deep.equal([`Extra field "field3"`]);
+      expect(getErrors(res1)).to.deep.equal([`Extra field "field3"`]);
 
       const res2 = validate({
         field1: 'present',
@@ -190,7 +208,7 @@ describe('validators', () => {
         field3: 'should not be here',
       });
       expect(isErr(res2)).to.be.true;
-      expect(res2.errors).to.deep.equal([`Extra field "field3"`]);
+      expect(getErrors(res2)).to.deep.equal([`Extra field "field3"`]);
     });
 
     it('should return an OK when the given data has no extra fields', () => {
@@ -198,14 +216,14 @@ describe('validators', () => {
         field1: 'here',
       });
       expect(isOK(res1)).to.be.true;
-      expect(res1.errors).to.deep.equal([]);
+      expect(getErrors(res1)).to.deep.equal([]);
 
       const res2 = validate({
         field1: 'here',
         field2: 'also here',
       });
       expect(isOK(res2)).to.be.true;
-      expect(res2.errors).to.deep.equal([]);
+      expect(getErrors(res2)).to.deep.equal([]);
     });
   });
 
@@ -213,7 +231,9 @@ describe('validators', () => {
     it('should return an Err when the given data is not an array', () => {
       const res = validateIsArray('string');
       expect(isErr(res)).to.be.true;
-      expect(res.errors).to.deep.equal([`Data was not an array`]);
+      expect(getErrors(res)).to.deep.equal([
+        `"string" failed to typecheck (expected array)`,
+      ]);
 
       expect(isErr(validateIsArray(1))).to.be.true;
       expect(isErr(validateIsArray({}))).to.be.true;
@@ -223,7 +243,7 @@ describe('validators', () => {
     it('should return an OK when the given data is an array', () => {
       const res = validateIsArray([]);
       expect(isOK(res)).to.be.true;
-      expect(res.errors).to.deep.equal([]);
+      expect(getErrors(res)).to.deep.equal([]);
 
       expect(isOK(validateIsArray([1, 2, 3]))).to.be.true;
     });
@@ -235,13 +255,13 @@ describe('validators', () => {
 
       const res1 = validate([1, '2', '3']);
       expect(isErr(res1)).to.be.true;
-      expect(res1.errors).to.deep.equal([
+      expect(getErrors(res1)).to.deep.equal([
         `Item "1" failed to typecheck (expected string)`,
       ]);
 
       const res2 = validate(['1', true]);
       expect(isErr(res2)).to.be.true;
-      expect(res2.errors).to.deep.equal([
+      expect(getErrors(res2)).to.deep.equal([
         `Item "true" failed to typecheck (expected string)`,
       ]);
     });
@@ -251,7 +271,7 @@ describe('validators', () => {
 
       const res = validate(['1', '2']);
       expect(isOK(res)).to.be.true;
-      expect(res.errors).to.deep.equal([]);
+      expect(getErrors(res)).to.deep.equal([]);
     });
   });
 
@@ -263,7 +283,7 @@ describe('validators', () => {
     it('should return an Err if any of the items fail the given validator', () => {
       const res = validate([2, 3, 4]);
       expect(isErr(res)).to.be.true;
-      expect(res.errors).to.deep.equal([
+      expect(getErrors(res)).to.deep.equal([
         `At item 0: 2 <= 3`,
         `At item 1: 3 <= 3`,
       ]);


### PR DESCRIPTION
This PR fixes #22 by adding the following validators:

- `fromPredicate` to construct a validator from a function that returns either true or false (we now make use of this internally, too)
- `validateIsIn` to validate whether a value is contained within an array of values
- `validateIsType` to validate whether a value is of a given type

I also added a `prefixErrors` helper function which simplifies the most common use of `mapErrors`.

The version is bumped to 0.5.2.