### PR TITLE
Error printing

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,5 @@
+node_modules
+coverage
+flow-coverage
+flow-typed
+dist

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,19 @@
+{
+  "env": { "es6": true, "node": true },
+  "globals": {},
+  "extends": ["eslint:recommended"],
+  "rules": {
+    "linebreak-style": ["error", "unix"],
+    "no-eval": ["error"],
+    "eqeqeq": ["error"],
+    "no-unused-expressions": 1
+  },
+  "parser": "babel-eslint",
+  "parserOptions": {
+    "sourceType": "module",
+    "ecmaFeatures": {
+      "experimentalObjectRestSpread": true
+    }
+  },
+  "plugins": ["flowtype"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 coverage
 dist
 .nyc_output
+yarn-error.log

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "trailingComma": "es5",
+  "singleQuote": true
+}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 [![Build Status](https://travis-ci.org/times/data-validator.svg?branch=master)](https://travis-ci.org/times/data-validator) [![Code coverage](https://codecov.io/gh/times/data-validator/branch/master/graph/badge.svg)](https://codecov.io/gh/times/data-validator) [![npm version](https://badge.fury.io/js/%40times%2Fdata-validator.svg)](https://badge.fury.io/js/%40times%2Fdata-validator)
 
-
 ## Use
 
 Validate an object based on a schema:
@@ -12,71 +11,68 @@ Validate an object based on a schema:
 ```js
 const { objectValidator, ok, err } = require('@times/data-validator');
 
-const objectSchema = {
+const personSchema = {
   name: {
     type: 'string',
     required: true,
-    validator: s => s.length <= 10 ? ok() : err([`"${s}" was longer than 10`]),
+    validator: s => (s.length <= 10 ? ok() : err(`"${s}" was longer than 10`)),
   },
   age: {
     type: 'number',
-    required: false
-  }
+    required: false,
+  },
 };
 
-const isValid = objectValidator(objectSchema);
+const validatePerson = objectValidator(personSchema);
 
 const alice = {
   name: 'Alice',
-  age: 23
+  age: 23,
 };
-isValid(alice); // { valid: true, errors: [] }
+validatePerson(alice); // { valid: true }
 
 const bob = {
-  age: 'thirty'
+  age: 'thirty',
 };
-isValid(bob); // { valid: false, errors: [ `Missing required field "name"`, `Field "age" failed to typecheck (expected number)` ] }
+validatePerson(bob); // { valid: false, errors: [ `Missing required field "name"`, `Field "age" failed to typecheck (expected number)` ] }
 
 const christopher = {
   name: 'Christopher',
-}
-isValid(christopher); // { valid: false, errors: [ `At field "name": "Christopher" was longer than 10` ] }
+};
+validatePerson(christopher); // { valid: false, errors: [ `At field "name": "Christopher" was longer than 10` ] }
 ```
-
 
 Validate an array based on a schema:
 
 ```js
 const { arrayValidator, ok, err } = require('@times/data-validator');
 
-const arraySchema = {
+const numberSchema = {
   type: 'number',
-  validator: n => n >= 10 ? ok() : err([`${n} was less than 10`])
+  validator: n => (n >= 10 ? ok() : err([`${n} was less than 10`])),
 };
 
-const isValid = arrayValidator(arraySchema);
+const validateNumber = arrayValidator(numberSchema);
 
-const numbers1 = [ 9, 10, 11 ];
-isValid(numbers1); // { valid: false, errors: [ `At item 0: 9 was less than 10` ] }
+const numbers1 = [9, 10, 11];
+validateNumber(numbers1); // { valid: false, errors: [ `At item 0: 9 was less than 10` ] }
 
-const numbers2 = [ 'ten', 11 ];
-isValid(numbers2); // { valid: false, errors: [ `Item "ten" failed to typecheck (expected number)` ] }
+const numbers2 = ['ten', 11];
+validateNumber(numbers2); // { valid: false, errors: [ `Item "ten" failed to typecheck (expected number)` ] }
 ```
-
 
 ## Schema properties
 
 An object schema consists of field names that map to sets of properties. Each set of properties can optionally include:
 
-- `type`: the type of the field. Can be string, number, date, array, object, function...
-- `required`: whether the field is required. Should be true or false
-- `validator`: a nested validator that should be applied to the contents of the field
+* `type`: the type of the field. Can be string, number, date, array, object, function...
+* `required`: whether the field is required. Should be true or false
+* `validator`: a nested validator that should be applied to the contents of the field
 
 An array schema can similarly have the following optional properties:
 
-- `type`: the type of the items in the array
-- `validator`: a nested validator that should be applied to each item in the array
-
+* `type`: the type of the items in the array
+* `validator`: a nested validator that should be applied to each item in the array
 
 ## Compose
 
@@ -84,12 +80,12 @@ Two useful functions, `objectValidator` and `arrayValidator`, are provided by de
 
 If these functions are insufficient, however, there are several functions available for you to build and compose your own validators.
 
-A validator is any function with the signature `data -> Result`, where a Result can be constructed using the provided `ok()` or `err()` functions. `err()` accepts an array of error messages.
+A validator is any function with the signature `data -> Result`, where a Result can be constructed using the provided `ok()` or `err()` functions. `err()` accepts a single error message or an array of error messages.
 
 To chain multiple validators together you can use the `all` or `some` composition functions. For example:
 
 ```js
-const validatorOne = data => data <= 3 ? ok() : err([`Data was greater than three`]);
+const validatorOne = data => data <= 3 ? ok() : err(`Data was greater than three`);
 
 const validatorTwo = ...
 
@@ -110,19 +106,17 @@ const result2 = composedValidator2(data);
 
 You can of course write your own composition functions. A composition function must accept an array of validators and run them, somehow combining the Results into a single Result.
 
-
 ## Converting from schemas
 
 If you would like to use a schema beyond the supported object and array schemas, you can make use of the following exported functions:
 
-- `fromObjectSchema`: Converts an object schema to an array of validators
-- `fromObjectSchemaStrict`: Converts an object schema to an array of validators, including a validator that checks the object has no extra fields
-- `fromArraySchema`: Converts an array schema to an array of validators
+* `fromObjectSchema`: Converts an object schema to an array of validators
+* `fromObjectSchemaStrict`: Converts an object schema to an array of validators, including a validator that checks the object has no extra fields
+* `fromArraySchema`: Converts an array schema to an array of validators
 
 You can also write your own schema conversion functions should you wish.
 
 The resulting list of validators can then be combined into a single validator using `all`, `some` or your own composition function; this is how the default `objectValidator` and `arrayValidator` helpers work.
-
 
 ## Contributing
 
@@ -131,7 +125,6 @@ Pull requests are very welcome. Please include a clear description of any change
 During development you can run tests with
 
     yarn test
-
 
 The library uses Flow for type checking. You can run Flow with
 
@@ -142,7 +135,6 @@ You can build the project with
     yarn build
 
 The build process uses Rollup to generate UMD and ES module versions of the bundle.
-
 
 ## Contact
 

--- a/flow-typed/npm/ramda_v0.x.x.js
+++ b/flow-typed/npm/ramda_v0.x.x.js
@@ -1,0 +1,1838 @@
+// flow-typed signature: 36af050a4e6f03034e3ae6b63739f753
+// flow-typed version: 656f69c1c8/ramda_v0.x.x/flow_>=v0.39.x <=v0.48.x
+
+/* eslint-disable no-unused-vars, no-redeclare */
+
+type Transformer<A, B> = {
+  "@@transducer/step": <I, R>(r: A, a: *) => R,
+  "@@transducer/init": () => A,
+  "@@transducer/result": (result: *) => B
+};
+
+declare type $npm$ramda$Placeholder = { "@@functional/placeholder": true };
+
+declare module ramda {
+  declare type UnaryFn<A, R> = (a: A) => R;
+  declare type BinaryFn<A, B, R> = ((a: A, b: B) => R) &
+    ((a: A) => (b: B) => R);
+  declare type UnarySameTypeFn<T> = UnaryFn<T, T>;
+  declare type BinarySameTypeFn<T> = BinaryFn<T, T, T>;
+  declare type NestedObject<T> = { [k: string]: T | NestedObject<T> };
+  declare type UnaryPredicateFn<T> = (x: T) => boolean;
+  declare type MapUnaryPredicateFn = <V>(V) => V => boolean;
+  declare type BinaryPredicateFn<T> = (x: T, y: T) => boolean;
+  declare type BinaryPredicateFn2<T, S> = (x: T, y: S) => boolean;
+
+  declare interface ObjPredicate {
+    (value: any, key: string): boolean;
+  }
+
+  declare type __CurriedFunction1<A, R, AA: A> = (...r: [AA]) => R;
+  declare type CurriedFunction1<A, R> = __CurriedFunction1<A, R, *>;
+
+  declare type __CurriedFunction2<A, B, R, AA: A, BB: B> = ((
+    ...r: [AA]
+  ) => CurriedFunction1<BB, R>) &
+    ((...r: [AA, BB]) => R);
+  declare type CurriedFunction2<A, B, R> = __CurriedFunction2<A, B, R, *, *>;
+
+  declare type __CurriedFunction3<A, B, C, R, AA: A, BB: B, CC: C> = ((
+    ...r: [AA]
+  ) => CurriedFunction2<BB, CC, R>) &
+    ((...r: [AA, BB]) => CurriedFunction1<CC, R>) &
+    ((...r: [AA, BB, CC]) => R);
+  declare type CurriedFunction3<A, B, C, R> = __CurriedFunction3<
+    A,
+    B,
+    C,
+    R,
+    *,
+    *,
+    *
+  >;
+
+  declare type __CurriedFunction4<
+    A,
+    B,
+    C,
+    D,
+    R,
+    AA: A,
+    BB: B,
+    CC: C,
+    DD: D
+  > = ((...r: [AA]) => CurriedFunction3<BB, CC, DD, R>) &
+    ((...r: [AA, BB]) => CurriedFunction2<CC, DD, R>) &
+    ((...r: [AA, BB, CC]) => CurriedFunction1<DD, R>) &
+    ((...r: [AA, BB, CC, DD]) => R);
+  declare type CurriedFunction4<A, B, C, D, R> = __CurriedFunction4<
+    A,
+    B,
+    C,
+    D,
+    R,
+    *,
+    *,
+    *,
+    *
+  >;
+
+  declare type __CurriedFunction5<
+    A,
+    B,
+    C,
+    D,
+    E,
+    R,
+    AA: A,
+    BB: B,
+    CC: C,
+    DD: D,
+    EE: E
+  > = ((...r: [AA]) => CurriedFunction4<BB, CC, DD, EE, R>) &
+    ((...r: [AA, BB]) => CurriedFunction3<CC, DD, EE, R>) &
+    ((...r: [AA, BB, CC]) => CurriedFunction2<DD, EE, R>) &
+    ((...r: [AA, BB, CC, DD]) => CurriedFunction1<EE, R>) &
+    ((...r: [AA, BB, CC, DD, EE]) => R);
+  declare type CurriedFunction5<A, B, C, D, E, R> = __CurriedFunction5<
+    A,
+    B,
+    C,
+    D,
+    E,
+    R,
+    *,
+    *,
+    *,
+    *,
+    *
+  >;
+
+  declare type __CurriedFunction6<
+    A,
+    B,
+    C,
+    D,
+    E,
+    F,
+    R,
+    AA: A,
+    BB: B,
+    CC: C,
+    DD: D,
+    EE: E,
+    FF: F
+  > = ((...r: [AA]) => CurriedFunction5<BB, CC, DD, EE, FF, R>) &
+    ((...r: [AA, BB]) => CurriedFunction4<CC, DD, EE, FF, R>) &
+    ((...r: [AA, BB, CC]) => CurriedFunction3<DD, EE, FF, R>) &
+    ((...r: [AA, BB, CC, DD]) => CurriedFunction2<EE, FF, R>) &
+    ((...r: [AA, BB, CC, DD, EE]) => CurriedFunction1<FF, R>) &
+    ((...r: [AA, BB, CC, DD, EE, FF]) => R);
+  declare type CurriedFunction6<A, B, C, D, E, F, R> = __CurriedFunction6<
+    A,
+    B,
+    C,
+    D,
+    E,
+    F,
+    R,
+    *,
+    *,
+    *,
+    *,
+    *,
+    *
+  >;
+
+  declare type Curry = (<A, R>((...r: [A]) => R) => CurriedFunction1<A, R>) &
+    (<A, B, R>((...r: [A, B]) => R) => CurriedFunction2<A, B, R>) &
+    (<A, B, C, R>((...r: [A, B, C]) => R) => CurriedFunction3<A, B, C, R>) &
+    (<A, B, C, D, R>(
+      (...r: [A, B, C, D]) => R
+    ) => CurriedFunction4<A, B, C, D, R>) &
+    (<A, B, C, D, E, R>(
+      (...r: [A, B, C, D, E]) => R
+    ) => CurriedFunction5<A, B, C, D, E, R>) &
+    (<A, B, C, D, E, F, R>(
+      (...r: [A, B, C, D, E, F]) => R
+    ) => CurriedFunction6<A, B, C, D, E, F, R>);
+
+  declare type Partial = (<A, R>((...r: [A]) => R, args: [A]) => () => R) &
+    (<A, B, R>((...r: [A, B]) => R, args: [A]) => CurriedFunction1<B, R>) &
+    (<A, B, R>((...r: [A, B]) => R, args: [A, B]) => () => R) &
+    (<A, B, C, R>(
+      (...r: [A, B, C]) => R,
+      args: [A]
+    ) => CurriedFunction2<B, C, R>) &
+    (<A, B, C, R>(
+      (...r: [A, B, C]) => R,
+      args: [A, B]
+    ) => CurriedFunction1<C, R>) &
+    (<A, B, C, R>((...r: [A, B, C]) => R, args: [A, B, C]) => () => R) &
+    (<A, B, C, D, R>(
+      (...r: [A, B, C, D]) => R,
+      args: [A]
+    ) => CurriedFunction3<B, C, D, R>) &
+    (<A, B, C, D, R>(
+      (...r: [A, B, C, D]) => R,
+      args: [A, B]
+    ) => CurriedFunction2<C, D, R>) &
+    (<A, B, C, D, R>(
+      (...r: [A, B, C, D]) => R,
+      args: [A, B, C]
+    ) => CurriedFunction1<D, R>) &
+    (<A, B, C, D, R>(
+      (...r: [A, B, C, D]) => R,
+      args: [A, B, C, D]
+    ) => () => R) &
+    (<A, B, C, D, E, R>(
+      (...r: [A, B, C, D, E]) => R,
+      args: [A]
+    ) => CurriedFunction4<B, C, D, E, R>) &
+    (<A, B, C, D, E, R>(
+      (...r: [A, B, C, D, E]) => R,
+      args: [A, B]
+    ) => CurriedFunction3<C, D, E, R>) &
+    (<A, B, C, D, E, R>(
+      (...r: [A, B, C, D, E]) => R,
+      args: [A, B, C]
+    ) => CurriedFunction2<D, E, R>) &
+    (<A, B, C, D, E, R>(
+      (...r: [A, B, C, D, E]) => R,
+      args: [A, B, C, D]
+    ) => CurriedFunction1<E, R>) &
+    (<A, B, C, D, E, R>(
+      (...r: [A, B, C, D, E]) => R,
+      args: [A, B, C, D, E]
+    ) => () => R) &
+    (<A, B, C, D, E, F, R>(
+      (...r: [A, B, C, D, E, F]) => R,
+      args: [A]
+    ) => CurriedFunction5<B, C, D, E, F, R>) &
+    (<A, B, C, D, E, F, R>(
+      (...r: [A, B, C, D, E, F]) => R,
+      args: [A, B]
+    ) => CurriedFunction4<C, D, E, F, R>) &
+    (<A, B, C, D, E, F, R>(
+      (...r: [A, B, C, D, E, F]) => R,
+      args: [A, B, C]
+    ) => CurriedFunction3<D, E, F, R>) &
+    (<A, B, C, D, E, F, R>(
+      (...r: [A, B, C, D, E, F]) => R,
+      args: [A, B, C, D]
+    ) => CurriedFunction2<E, F, R>) &
+    (<A, B, C, D, E, F, R>(
+      (...r: [A, B, C, D, E, F]) => R,
+      args: [A, B, C, D, E]
+    ) => CurriedFunction1<F, R>) &
+    (<A, B, C, D, E, F, R>(
+      (...r: [A, B, C, D, E, F]) => R,
+      args: [A, B, C, D, E, F]
+    ) => () => R);
+
+  declare type Pipe = (<A, B, C, D, E, F, G>(
+    ab: UnaryFn<A, B>,
+    bc: UnaryFn<B, C>,
+    cd: UnaryFn<C, D>,
+    de: UnaryFn<D, E>,
+    ef: UnaryFn<E, F>,
+    fg: UnaryFn<F, G>,
+    ...rest: Array<void>
+  ) => UnaryFn<A, G>) &
+    (<A, B, C, D, E, F>(
+      ab: UnaryFn<A, B>,
+      bc: UnaryFn<B, C>,
+      cd: UnaryFn<C, D>,
+      de: UnaryFn<D, E>,
+      ef: UnaryFn<E, F>,
+      ...rest: Array<void>
+    ) => UnaryFn<A, F>) &
+    (<A, B, C, D, E>(
+      ab: UnaryFn<A, B>,
+      bc: UnaryFn<B, C>,
+      cd: UnaryFn<C, D>,
+      de: UnaryFn<D, E>,
+      ...rest: Array<void>
+    ) => UnaryFn<A, E>) &
+    (<A, B, C, D>(
+      ab: UnaryFn<A, B>,
+      bc: UnaryFn<B, C>,
+      cd: UnaryFn<C, D>,
+      ...rest: Array<void>
+    ) => UnaryFn<A, D>) &
+    (<A, B, C>(
+      ab: UnaryFn<A, B>,
+      bc: UnaryFn<B, C>,
+      ...rest: Array<void>
+    ) => UnaryFn<A, C>) &
+    (<A, B>(ab: UnaryFn<A, B>, ...rest: Array<void>) => UnaryFn<A, B>);
+
+  declare type Compose = (<A, B, C, D, E, F, G>(
+    fg: UnaryFn<F, G>,
+    ef: UnaryFn<E, F>,
+    de: UnaryFn<D, E>,
+    cd: UnaryFn<C, D>,
+    bc: UnaryFn<B, C>,
+    ab: UnaryFn<A, B>,
+    ...rest: Array<void>
+  ) => UnaryFn<A, G>) &
+    (<A, B, C, D, E, F>(
+      ef: UnaryFn<E, F>,
+      de: UnaryFn<D, E>,
+      cd: UnaryFn<C, D>,
+      bc: UnaryFn<B, C>,
+      ab: UnaryFn<A, B>,
+      ...rest: Array<void>
+    ) => UnaryFn<A, F>) &
+    (<A, B, C, D, E>(
+      de: UnaryFn<D, E>,
+      cd: UnaryFn<C, D>,
+      bc: UnaryFn<B, C>,
+      ab: UnaryFn<A, B>,
+      ...rest: Array<void>
+    ) => UnaryFn<A, E>) &
+    (<A, B, C, D>(
+      cd: UnaryFn<C, D>,
+      bc: UnaryFn<B, C>,
+      ab: UnaryFn<A, B>,
+      ...rest: Array<void>
+    ) => UnaryFn<A, D>) &
+    (<A, B, C>(
+      bc: UnaryFn<B, C>,
+      ab: UnaryFn<A, B>,
+      ...rest: Array<void>
+    ) => UnaryFn<A, C>) &
+    (<A, B>(ab: UnaryFn<A, B>, ...rest: Array<void>) => UnaryFn<A, B>);
+
+  declare type Filter = (<K, V, T: Array<V> | { [key: K]: V }>(
+    fn: UnaryPredicateFn<V>,
+    xs: T
+  ) => T) &
+    (<K, V, T: Array<V> | { [key: K]: V }>(
+      fn: UnaryPredicateFn<V>
+    ) => (xs: T) => T);
+
+  declare class Monad<T> {
+    chain: Function;
+  }
+
+  declare class Semigroup<T> {}
+
+  declare class Chain {
+    chain<T, V: Monad<T> | Array<T>>(fn: (a: T) => V, x: V): V;
+    chain<T, V: Monad<T> | Array<T>>(fn: (a: T) => V): (x: V) => V;
+  }
+
+  declare class GenericContructor<T> {
+    constructor(x: T): GenericContructor<any>;
+  }
+
+  declare class GenericContructorMulti {
+    constructor(...args: Array<any>): GenericContructor<any>;
+  }
+
+  /**
+   * DONE:
+   * Function*
+   * List*
+   * Logic
+   * Math
+   * Object*
+   * Relation
+   * String
+   * Type
+   */
+
+  declare var compose: Compose;
+  declare var pipe: Pipe;
+  declare var curry: Curry;
+  declare function curryN(
+    length: number,
+    fn: (...args: Array<any>) => any
+  ): Function;
+
+  // *Math
+  declare var add: CurriedFunction2<number, number, number>;
+  declare var inc: UnaryFn<number, number>;
+  declare var dec: UnaryFn<number, number>;
+  declare var mean: UnaryFn<Array<number>, number>;
+  declare var divide: CurriedFunction2<number, number, number>;
+  declare var mathMod: CurriedFunction2<number, number, number>;
+  declare var median: UnaryFn<Array<number>, number>;
+  declare var modulo: CurriedFunction2<number, number, number>;
+  declare var multiply: CurriedFunction2<number, number, number>;
+  declare var negate: UnaryFn<number, number>;
+  declare var product: UnaryFn<Array<number>, number>;
+  declare var subtract: CurriedFunction2<number, number, number>;
+  declare var sum: UnaryFn<Array<number>, number>;
+
+  // Filter
+  declare var filter: Filter;
+  declare var reject: Filter;
+
+  // *String
+  declare var match: CurriedFunction2<RegExp, string, Array<string | void>>;
+  declare var replace: CurriedFunction3<
+    RegExp | string,
+    string,
+    string,
+    string
+  >;
+  declare var split: CurriedFunction2<RegExp | string, string, Array<string>>;
+  declare var test: CurriedFunction2<RegExp, string, boolean>;
+  declare function toLower(a: string): string;
+  declare function toString(a: any): string;
+  declare function toUpper(a: string): string;
+  declare function trim(a: string): string;
+
+  // *Type
+  declare function is<T>(t: T, ...rest: Array<void>): (v: any) => boolean;
+  declare function is<T>(t: T, v: any): boolean;
+  declare var propIs: CurriedFunction3<any, string, Object, boolean>;
+  declare function type(x: ?any): string;
+  declare function isArrayLike(x: any): boolean;
+
+  declare function isNil(x: void | null): true;
+  declare function isNil(x: mixed): false;
+
+  // *List
+  declare function adjust<T>(
+    fn: (a: T) => T,
+    ...rest: Array<void>
+  ): (index: number, ...rest: Array<void>) => (src: Array<T>) => Array<T>;
+  declare function adjust<T>(
+    fn: (a: T) => T,
+    index: number,
+    ...rest: Array<void>
+  ): (src: Array<T>) => Array<T>;
+  declare function adjust<T>(
+    fn: (a: T) => T,
+    index: number,
+    src: Array<T>
+  ): Array<T>;
+
+  declare function all<T>(fn: UnaryPredicateFn<T>, xs: Array<T>): boolean;
+  declare function all<T>(
+    fn: UnaryPredicateFn<T>,
+    ...rest: Array<void>
+  ): (xs: Array<T>) => boolean;
+
+  declare function any<T>(fn: UnaryPredicateFn<T>, xs: Array<T>): boolean;
+  declare function any<T>(
+    fn: UnaryPredicateFn<T>,
+    ...rest: Array<void>
+  ): (xs: Array<T>) => boolean;
+
+  declare function aperture<T>(n: number, xs: Array<T>): Array<Array<T>>;
+  declare function aperture<T>(
+    n: number,
+    ...rest: Array<void>
+  ): (xs: Array<T>) => Array<Array<T>>;
+
+  declare function append<E>(x: E, xs: Array<E>): Array<E>;
+  declare function append<E>(
+    x: E,
+    ...rest: Array<void>
+  ): (xs: Array<E>) => Array<E>;
+
+  declare function prepend<E>(x: E, xs: Array<E>): Array<E>;
+  declare function prepend<E>(
+    x: E,
+    ...rest: Array<void>
+  ): (xs: Array<E>) => Array<E>;
+
+  declare function concat<V, T: Array<V> | string>(x: T, y: T): T;
+  declare function concat<V, T: Array<V> | string>(x: T): (y: T) => T;
+
+  declare function contains<E, T: Array<E> | string>(x: E, xs: T): boolean;
+  declare function contains<E, T: Array<E> | string>(
+    x: E,
+    ...rest: Array<void>
+  ): (xs: T) => boolean;
+
+  declare function drop<V, T: Array<V> | string>(
+    n: number,
+    ...rest: Array<void>
+  ): (xs: T) => T;
+  declare function drop<V, T: Array<V> | string>(n: number, xs: T): T;
+
+  declare function dropLast<V, T: Array<V> | string>(
+    n: number,
+    ...rest: Array<void>
+  ): (xs: T) => T;
+  declare function dropLast<V, T: Array<V> | string>(n: number, xs: T): T;
+
+  declare function dropLastWhile<V, T: Array<V>>(
+    fn: UnaryPredicateFn<V>,
+    ...rest: Array<void>
+  ): (xs: T) => T;
+  declare function dropLastWhile<V, T: Array<V>>(
+    fn: UnaryPredicateFn<V>,
+    xs: T
+  ): T;
+
+  declare function dropWhile<V, T: Array<V>>(
+    fn: UnaryPredicateFn<V>,
+    ...rest: Array<void>
+  ): (xs: T) => T;
+  declare function dropWhile<V, T: Array<V>>(fn: UnaryPredicateFn<V>, xs: T): T;
+
+  declare function dropRepeats<V, T: Array<V>>(xs: T): T;
+
+  declare function dropRepeatsWith<V, T: Array<V>>(
+    fn: BinaryPredicateFn<V>,
+    ...rest: Array<void>
+  ): (xs: T) => T;
+  declare function dropRepeatsWith<V, T: Array<V>>(
+    fn: BinaryPredicateFn<V>,
+    xs: T
+  ): T;
+
+  declare function groupBy<T>(
+    fn: (x: T) => string,
+    xs: Array<T>
+  ): { [key: string]: Array<T> };
+  declare function groupBy<T>(
+    fn: (x: T) => string,
+    ...rest: Array<void>
+  ): (xs: Array<T>) => { [key: string]: Array<T> };
+
+  declare function groupWith<T, V: Array<T> | string>(
+    fn: BinaryPredicateFn<T>,
+    xs: V
+  ): Array<V>;
+  declare function groupWith<T, V: Array<T> | string>(
+    fn: BinaryPredicateFn<T>,
+    ...rest: Array<void>
+  ): (xs: V) => Array<V>;
+
+  declare function head<T, V: Array<T>>(xs: V): ?T;
+  declare function head<T, V: string>(xs: V): V;
+
+  declare function into<I, T, A: Array<T>, R: Array<*> | string | Object>(
+    accum: R,
+    xf: (a: A) => I,
+    input: A
+  ): R;
+  declare function into<I, T, A: Array<T>, R>(
+    accum: Transformer<I, R>,
+    xf: (a: A) => R,
+    input: A
+  ): R;
+
+  declare function indexOf<E>(x: E, xs: Array<E>): number;
+  declare function indexOf<E>(
+    x: E,
+    ...rest: Array<void>
+  ): (xs: Array<E>) => number;
+
+  declare function indexBy<V, T: { [key: string]: * }>(
+    fn: (x: T) => string,
+    ...rest: Array<void>
+  ): (xs: Array<T>) => { [key: string]: T };
+  declare function indexBy<V, T: { [key: string]: * }>(
+    fn: (x: T) => string,
+    xs: Array<T>
+  ): { [key: string]: T };
+
+  declare function insert<T>(
+    index: number,
+    ...rest: Array<void>
+  ): (elem: T) => (src: Array<T>) => Array<T>;
+  declare function insert<T>(
+    index: number,
+    elem: T,
+    ...rest: Array<void>
+  ): (src: Array<T>) => Array<T>;
+  declare function insert<T>(index: number, elem: T, src: Array<T>): Array<T>;
+
+  declare function insertAll<T, S>(
+    index: number,
+    ...rest: Array<void>
+  ): (elem: Array<S>) => (src: Array<T>) => Array<S | T>;
+  declare function insertAll<T, S>(
+    index: number,
+    elems: Array<S>,
+    ...rest: Array<void>
+  ): (src: Array<T>) => Array<S | T>;
+  declare function insertAll<T, S>(
+    index: number,
+    elems: Array<S>,
+    src: Array<T>
+  ): Array<S | T>;
+
+  declare function join(x: string, xs: Array<any>): string;
+  declare function join(
+    x: string,
+    ...rest: Array<void>
+  ): (xs: Array<any>) => string;
+
+  declare function last<T, V: Array<T>>(xs: V): ?T;
+  declare function last<T, V: string>(xs: V): V;
+
+  declare function none<T>(fn: UnaryPredicateFn<T>, xs: Array<T>): boolean;
+  declare function none<T>(
+    fn: UnaryPredicateFn<T>,
+    ...rest: Array<void>
+  ): (xs: Array<T>) => boolean;
+
+  declare function nth<V, T: Array<V>>(i: number, xs: T): ?V;
+  declare function nth<V, T: Array<V> | string>(
+    i: number,
+    ...rest: Array<void>
+  ): ((xs: string) => string) & ((xs: T) => ?V);
+  declare function nth<T: string>(i: number, xs: T): T;
+
+  declare function find<V, O: { [key: string]: * }, T: Array<V> | O>(
+    fn: UnaryPredicateFn<V>,
+    ...rest: Array<void>
+  ): (xs: T | O) => ?V | O;
+  declare function find<V, O: { [key: string]: * }, T: Array<V> | O>(
+    fn: UnaryPredicateFn<V>,
+    xs: T | O
+  ): ?V | O;
+  declare function findLast<V, O: { [key: string]: * }, T: Array<V> | O>(
+    fn: UnaryPredicateFn<V>,
+    ...rest: Array<void>
+  ): (xs: T | O) => ?V | O;
+  declare function findLast<V, O: { [key: string]: * }, T: Array<V> | O>(
+    fn: UnaryPredicateFn<V>,
+    xs: T | O
+  ): ?V | O;
+
+  declare function findIndex<K, V, T: Array<V> | { [key: K]: V }>(
+    fn: UnaryPredicateFn<V>,
+    ...rest: Array<void>
+  ): (xs: T) => number;
+  declare function findIndex<K, V, T: Array<V> | { [key: K]: V }>(
+    fn: UnaryPredicateFn<V>,
+    xs: T
+  ): number;
+  declare function findLastIndex<K, V, T: Array<V> | { [key: K]: V }>(
+    fn: UnaryPredicateFn<V>,
+    ...rest: Array<void>
+  ): (xs: T) => number;
+  declare function findLastIndex<K, V, T: Array<V> | { [key: K]: V }>(
+    fn: UnaryPredicateFn<V>,
+    xs: T
+  ): number;
+
+  declare function forEach<T, V>(fn: (x: T) => ?V, xs: Array<T>): Array<T>;
+  declare function forEach<T, V>(
+    fn: (x: T) => ?V,
+    ...rest: Array<void>
+  ): (xs: Array<T>) => Array<T>;
+
+  declare function forEachObjIndexed<O: Object, A, B>(
+    fn: (val: A, key: string, o: O) => B,
+    o: { [key: string]: A }
+  ): O;
+
+  declare function forEachObjIndexed<O: Object, A, B>(
+    fn: (val: A, key: string, o: O) => B,
+    ...args: Array<void>
+  ): (o: { [key: string]: A }) => O;
+
+  declare function lastIndexOf<E>(x: E, xs: Array<E>): number;
+  declare function lastIndexOf<E>(
+    x: E,
+    ...rest: Array<void>
+  ): (xs: Array<E>) => number;
+
+  declare function map<T, R>(fn: (x: T) => R, xs: Array<T>): Array<R>;
+  declare function map<T, R, S: { map: Function }>(fn: (x: T) => R, xs: S): S;
+  declare function map<T, R>(
+    fn: (x: T) => R,
+    ...rest: Array<void>
+  ): ((xs: { [key: string]: T }) => { [key: string]: R }) &
+    ((xs: Array<T>) => Array<R>);
+  declare function map<T, R, S: { map: Function }>(
+    fn: (x: T) => R,
+    ...rest: Array<void>
+  ): ((xs: S) => S) & ((xs: S) => S);
+  declare function map<T, R>(
+    fn: (x: T) => R,
+    xs: { [key: string]: T }
+  ): { [key: string]: R };
+
+  declare type AccumIterator<A, B, R> = (acc: R, x: A) => [R, B];
+  declare function mapAccum<A, B, R>(
+    fn: AccumIterator<A, B, R>,
+    acc: R,
+    xs: Array<A>
+  ): [R, Array<B>];
+  declare function mapAccum<A, B, R>(
+    fn: AccumIterator<A, B, R>,
+    ...rest: Array<void>
+  ): (acc: R, xs: Array<A>) => [R, Array<B>];
+
+  declare function mapAccumRight<A, B, R>(
+    fn: AccumIterator<A, B, R>,
+    acc: R,
+    xs: Array<A>
+  ): [R, Array<B>];
+  declare function mapAccumRight<A, B, R>(
+    fn: AccumIterator<A, B, R>,
+    ...rest: Array<void>
+  ): (acc: R, xs: Array<A>) => [R, Array<B>];
+
+  declare function intersperse<E>(x: E, xs: Array<E>): Array<E>;
+  declare function intersperse<E>(
+    x: E,
+    ...rest: Array<void>
+  ): (xs: Array<E>) => Array<E>;
+
+  declare function pair<A, B>(a: A, b: B): [A, B];
+  declare function pair<A, B>(a: A, ...rest: Array<void>): (b: B) => [A, B];
+
+  declare function partition<K, V, T: Array<V> | { [key: K]: V }>(
+    fn: UnaryPredicateFn<V>,
+    xs: T
+  ): [T, T];
+  declare function partition<K, V, T: Array<V> | { [key: K]: V }>(
+    fn: UnaryPredicateFn<V>,
+    ...rest: Array<void>
+  ): (xs: T) => [T, T];
+
+  declare function pluck<
+    V,
+    K: string | number,
+    T: Array<Array<V> | { [key: string]: V }>
+  >(
+    k: K,
+    xs: T
+  ): Array<V>;
+  declare function pluck<
+    V,
+    K: string | number,
+    T: Array<Array<V> | { [key: string]: V }>
+  >(
+    k: K,
+    ...rest: Array<void>
+  ): (xs: T) => Array<V>;
+
+  declare var range: CurriedFunction2<number, number, Array<number>>;
+
+  declare function remove<T>(
+    from: number,
+    ...rest: Array<void>
+  ): ((to: number, ...rest: Array<void>) => (src: Array<T>) => Array<T>) &
+    ((to: number, src: Array<T>) => Array<T>);
+  declare function remove<T>(
+    from: number,
+    to: number,
+    ...rest: Array<void>
+  ): (src: Array<T>) => Array<T>;
+  declare function remove<T>(from: number, to: number, src: Array<T>): Array<T>;
+
+  declare function repeat<T>(x: T, times: number): Array<T>;
+  declare function repeat<T>(
+    x: T,
+    ...rest: Array<void>
+  ): (times: number) => Array<T>;
+
+  declare function slice<V, T: Array<V> | string>(
+    from: number,
+    ...rest: Array<void>
+  ): ((to: number, ...rest: Array<void>) => (src: T) => T) &
+    ((to: number, src: T) => T);
+  declare function slice<V, T: Array<V> | string>(
+    from: number,
+    to: number,
+    ...rest: Array<void>
+  ): (src: T) => T;
+  declare function slice<V, T: Array<V> | string>(
+    from: number,
+    to: number,
+    src: T
+  ): T;
+
+  declare function sort<V, T: Array<V>>(fn: (a: V, b: V) => number, xs: T): T;
+  declare function sort<V, T: Array<V>>(
+    fn: (a: V, b: V) => number,
+    ...rest: Array<void>
+  ): (xs: T) => T;
+
+  declare function times<T>(fn: (i: number) => T, n: number): Array<T>;
+  declare function times<T>(
+    fn: (i: number) => T,
+    ...rest: Array<void>
+  ): (n: number) => Array<T>;
+
+  declare function take<V, T: Array<V> | string>(n: number, xs: T): T;
+  declare function take<V, T: Array<V> | string>(n: number): (xs: T) => T;
+
+  declare function takeLast<V, T: Array<V> | string>(n: number, xs: T): T;
+  declare function takeLast<V, T: Array<V> | string>(n: number): (xs: T) => T;
+
+  declare function takeLastWhile<V, T: Array<V>>(
+    fn: UnaryPredicateFn<V>,
+    xs: T
+  ): T;
+  declare function takeLastWhile<V, T: Array<V>>(
+    fn: UnaryPredicateFn<V>
+  ): (xs: T) => T;
+
+  declare function takeWhile<V, T: Array<V>>(fn: UnaryPredicateFn<V>, xs: T): T;
+  declare function takeWhile<V, T: Array<V>>(
+    fn: UnaryPredicateFn<V>
+  ): (xs: T) => T;
+
+  declare function unfold<T, R>(
+    fn: (seed: T) => [R, T] | boolean,
+    ...rest: Array<void>
+  ): (seed: T) => Array<R>;
+  declare function unfold<T, R>(
+    fn: (seed: T) => [R, T] | boolean,
+    seed: T
+  ): Array<R>;
+
+  declare function uniqBy<T, V>(
+    fn: (x: T) => V,
+    ...rest: Array<void>
+  ): (xs: Array<T>) => Array<T>;
+  declare function uniqBy<T, V>(fn: (x: T) => V, xs: Array<T>): Array<T>;
+
+  declare function uniqWith<T>(
+    fn: BinaryPredicateFn<T>,
+    ...rest: Array<void>
+  ): (xs: Array<T>) => Array<T>;
+  declare function uniqWith<T>(
+    fn: BinaryPredicateFn<T>,
+    xs: Array<T>
+  ): Array<T>;
+
+  declare function update<T>(
+    index: number,
+    ...rest: Array<void>
+  ): ((elem: T, ...rest: Array<void>) => (src: Array<T>) => Array<T>) &
+    ((elem: T, src: Array<T>) => Array<T>);
+  declare function update<T>(
+    index: number,
+    elem: T,
+    ...rest: Array<void>
+  ): (src: Array<T>) => Array<T>;
+  declare function update<T>(index: number, elem: T, src: Array<T>): Array<T>;
+
+  // TODO `without` as a transducer
+  declare function without<T>(xs: Array<T>, src: Array<T>): Array<T>;
+  declare function without<T>(
+    xs: Array<T>,
+    ...rest: Array<void>
+  ): (src: Array<T>) => Array<T>;
+
+  declare function xprod<T, S>(xs: Array<T>, ys: Array<S>): Array<[T, S]>;
+  declare function xprod<T, S>(
+    xs: Array<T>,
+    ...rest: Array<void>
+  ): (ys: Array<S>) => Array<[T, S]>;
+
+  declare function zip<T, S>(xs: Array<T>, ys: Array<S>): Array<[T, S]>;
+  declare function zip<T, S>(
+    xs: Array<T>,
+    ...rest: Array<void>
+  ): (ys: Array<S>) => Array<[T, S]>;
+
+  declare function zipObj<T: string, S>(
+    xs: Array<T>,
+    ys: Array<S>
+  ): { [key: T]: S };
+  declare function zipObj<T: string, S>(
+    xs: Array<T>,
+    ...rest: Array<void>
+  ): (ys: Array<S>) => { [key: T]: S };
+
+  declare type NestedArray<T> = Array<T | NestedArray<T>>;
+  declare function flatten<T>(xs: NestedArray<T>): Array<T>;
+
+  declare function fromPairs<T, V>(pair: Array<[T, V]>): { [key: string]: V };
+
+  declare function init<T, V: Array<T> | string>(xs: V): V;
+
+  declare function length<T>(xs: Array<T>): number;
+
+  declare function mergeAll(
+    objs: Array<{ [key: string]: any }>
+  ): { [key: string]: any };
+
+  declare function reverse<T, V: Array<T> | string>(xs: V): V;
+
+  declare function reduce<A, B>(
+    fn: (acc: A, elem: B) => A,
+    ...rest: Array<void>
+  ): ((init: A, xs: Array<B>) => A) &
+    ((init: A, ...rest: Array<void>) => (xs: Array<B>) => A);
+  declare function reduce<A, B>(
+    fn: (acc: A, elem: B) => A,
+    init: A,
+    ...rest: Array<void>
+  ): (xs: Array<B>) => A;
+  declare function reduce<A, B>(
+    fn: (acc: A, elem: B) => A,
+    init: A,
+    xs: Array<B>
+  ): A;
+
+  declare function reduceBy<A, B>(
+    fn: (acc: B, elem: A) => B,
+    ...rest: Array<void>
+  ): ((
+    acc: B,
+    ...rest: Array<void>
+  ) => ((
+    keyFn: (elem: A) => string,
+    ...rest: Array<void>
+  ) => (xs: Array<A>) => { [key: string]: B }) &
+    ((keyFn: (elem: A) => string, xs: Array<A>) => { [key: string]: B })) &
+    ((
+      acc: B,
+      keyFn: (elem: A) => string,
+      ...rest: Array<void>
+    ) => (xs: Array<A>) => { [key: string]: B }) &
+    ((
+      acc: B,
+      keyFn: (elem: A) => string,
+      xs: Array<A>
+    ) => { [key: string]: B });
+  declare function reduceBy<A, B>(
+    fn: (acc: B, elem: A) => B,
+    acc: B,
+    ...rest: Array<void>
+  ): ((
+    keyFn: (elem: A) => string,
+    ...rest: Array<void>
+  ) => (xs: Array<A>) => { [key: string]: B }) &
+    ((keyFn: (elem: A) => string, xs: Array<A>) => { [key: string]: B });
+  declare function reduceBy<A, B>(
+    fn: (acc: B, elem: A) => B,
+    acc: B,
+    keyFn: (elem: A) => string
+  ): (xs: Array<A>) => { [key: string]: B };
+  declare function reduceBy<A, B>(
+    fn: (acc: B, elem: A) => B,
+    acc: B,
+    keyFn: (elem: A) => string,
+    xs: Array<A>
+  ): { [key: string]: B };
+
+  declare function reduceRight<A, B>(
+    fn: (acc: A, elem: B) => A,
+    ...rest: Array<void>
+  ): ((init: A, xs: Array<B>) => A) &
+    ((init: A, ...rest: Array<void>) => (xs: Array<B>) => A);
+  declare function reduceRight<A, B>(
+    fn: (acc: A, elem: B) => A,
+    init: A,
+    ...rest: Array<void>
+  ): (xs: Array<B>) => A;
+  declare function reduceRight<A, B>(
+    fn: (acc: A, elem: B) => A,
+    init: A,
+    xs: Array<B>
+  ): A;
+
+  declare function scan<A, B>(
+    fn: (acc: A, elem: B) => A,
+    ...rest: Array<void>
+  ): ((init: A, xs: Array<B>) => Array<A>) &
+    ((init: A, ...rest: Array<void>) => (xs: Array<B>) => Array<A>);
+  declare function scan<A, B>(
+    fn: (acc: A, elem: B) => A,
+    init: A,
+    ...rest: Array<void>
+  ): (xs: Array<B>) => Array<A>;
+  declare function scan<A, B>(
+    fn: (acc: A, elem: B) => A,
+    init: A,
+    xs: Array<B>
+  ): Array<A>;
+
+  declare function splitAt<V, T: Array<V> | string>(i: number, xs: T): [T, T];
+  declare function splitAt<V, T: Array<V> | string>(
+    i: number
+  ): (xs: T) => [T, T];
+  declare function splitEvery<V, T: Array<V> | string>(
+    i: number,
+    xs: T
+  ): Array<T>;
+  declare function splitEvery<V, T: Array<V> | string>(
+    i: number
+  ): (xs: T) => Array<T>;
+  declare function splitWhen<V, T: Array<V>>(
+    fn: UnaryPredicateFn<V>,
+    xs: T
+  ): [T, T];
+  declare function splitWhen<V, T: Array<V>>(
+    fn: UnaryPredicateFn<V>
+  ): (xs: T) => [T, T];
+
+  declare function tail<T, V: Array<T> | string>(xs: V): V;
+
+  declare function transpose<T>(xs: Array<Array<T>>): Array<Array<T>>;
+
+  declare function uniq<T>(xs: Array<T>): Array<T>;
+
+  declare function unnest<T>(xs: NestedArray<T>): NestedArray<T>;
+
+  declare function zipWith<T, S, R>(
+    fn: (a: T, b: S) => R,
+    ...rest: Array<void>
+  ): ((xs: Array<T>, ys: Array<S>) => Array<R>) &
+    ((xs: Array<T>, ...rest: Array<void>) => (ys: Array<S>) => Array<R>);
+  declare function zipWith<T, S, R>(
+    fn: (a: T, b: S) => R,
+    xs: Array<T>,
+    ...rest: Array<void>
+  ): (ys: Array<S>) => Array<R>;
+  declare function zipWith<T, S, R>(
+    fn: (a: T, b: S) => R,
+    xs: Array<T>,
+    ys: Array<S>
+  ): Array<R>;
+
+  // *Relation
+  declare function equals<T>(x: T, ...rest: Array<void>): (y: T) => boolean;
+  declare function equals<T>(x: T, y: T): boolean;
+
+  declare function eqBy<A, B>(
+    fn: (x: A) => B,
+    ...rest: Array<void>
+  ): ((x: A, y: A) => boolean) &
+    ((x: A, ...rest: Array<void>) => (y: A) => boolean);
+  declare function eqBy<A, B>(
+    fn: (x: A) => B,
+    x: A,
+    ...rest: Array<void>
+  ): (y: A) => boolean;
+  declare function eqBy<A, B>(fn: (x: A) => B, x: A, y: A): boolean;
+
+  declare function propEq(
+    prop: string,
+    ...rest: Array<void>
+  ): ((val: *, o: { [k: string]: * }) => boolean) &
+    ((val: *, ...rest: Array<void>) => (o: { [k: string]: * }) => boolean);
+  declare function propEq(
+    prop: string,
+    val: *,
+    ...rest: Array<void>
+  ): (o: { [k: string]: * }) => boolean;
+  declare function propEq(prop: string, val: *, o: { [k: string]: * }): boolean;
+
+  declare function pathEq(
+    path: Array<string>,
+    ...rest: Array<void>
+  ): ((val: any, o: Object) => boolean) &
+    ((val: any, ...rest: Array<void>) => (o: Object) => boolean);
+  declare function pathEq(
+    path: Array<string>,
+    val: any,
+    ...rest: Array<void>
+  ): (o: Object) => boolean;
+  declare function pathEq(path: Array<string>, val: any, o: Object): boolean;
+
+  declare function clamp<T: number | string | Date>(
+    min: T,
+    ...rest: Array<void>
+  ): ((max: T, ...rest: Array<void>) => (v: T) => T) & ((max: T, v: T) => T);
+  declare function clamp<T: number | string | Date>(
+    min: T,
+    max: T,
+    ...rest: Array<void>
+  ): (v: T) => T;
+  declare function clamp<T: number | string | Date>(min: T, max: T, v: T): T;
+
+  declare function countBy<T>(
+    fn: (x: T) => string,
+    ...rest: Array<void>
+  ): (list: Array<T>) => { [key: string]: number };
+  declare function countBy<T>(
+    fn: (x: T) => string,
+    list: Array<T>
+  ): { [key: string]: number };
+
+  declare function difference<T>(
+    xs1: Array<T>,
+    ...rest: Array<void>
+  ): (xs2: Array<T>) => Array<T>;
+  declare function difference<T>(xs1: Array<T>, xs2: Array<T>): Array<T>;
+
+  declare function differenceWith<T>(
+    fn: BinaryPredicateFn<T>,
+    ...rest: Array<void>
+  ): ((xs1: Array<T>) => (xs2: Array<T>) => Array<T>) &
+    ((xs1: Array<T>, xs2: Array<T>) => Array<T>);
+  declare function differenceWith<T>(
+    fn: BinaryPredicateFn<T>,
+    xs1: Array<T>,
+    ...rest: Array<void>
+  ): (xs2: Array<T>) => Array<T>;
+  declare function differenceWith<T>(
+    fn: BinaryPredicateFn<T>,
+    xs1: Array<T>,
+    xs2: Array<T>
+  ): Array<T>;
+
+  declare function eqBy<T>(fn: (x: T) => T, x: T, y: T): boolean;
+  declare function eqBy<T>(fn: (x: T) => T): (x: T, y: T) => boolean;
+  declare function eqBy<T>(fn: (x: T) => T, x: T): (y: T) => boolean;
+  declare function eqBy<T>(fn: (x: T) => T): (x: T) => (y: T) => boolean;
+
+  declare function gt<T>(x: T, ...rest: Array<void>): (y: T) => boolean;
+  declare function gt<T>(x: T, y: T): boolean;
+
+  declare function gte<T>(x: T, ...rest: Array<void>): (y: T) => boolean;
+  declare function gte<T>(x: T, y: T): boolean;
+
+  declare function identical<T>(x: T, ...rest: Array<void>): (y: T) => boolean;
+  declare function identical<T>(x: T, y: T): boolean;
+
+  declare function intersection<T>(x: Array<T>, y: Array<T>): Array<T>;
+  declare function intersection<T>(x: Array<T>): (y: Array<T>) => Array<T>;
+
+  declare function intersectionWith<T>(
+    fn: BinaryPredicateFn<T>,
+    ...rest: Array<void>
+  ): ((x: Array<T>, y: Array<T>) => Array<T>) &
+    ((x: Array<T>) => (y: Array<T>) => Array<T>);
+  declare function intersectionWith<T>(
+    fn: BinaryPredicateFn<T>,
+    x: Array<T>,
+    ...rest: Array<void>
+  ): (y: Array<T>) => Array<T>;
+  declare function intersectionWith<T>(
+    fn: BinaryPredicateFn<T>,
+    x: Array<T>,
+    y: Array<T>
+  ): Array<T>;
+
+  declare function lt<T>(x: T, ...rest: Array<void>): (y: T) => boolean;
+  declare function lt<T>(x: T, y: T): boolean;
+
+  declare function lte<T>(x: T, ...rest: Array<void>): (y: T) => boolean;
+  declare function lte<T>(x: T, y: T): boolean;
+
+  declare function max<T>(x: T, ...rest: Array<void>): (y: T) => T;
+  declare function max<T>(x: T, y: T): T;
+
+  declare function maxBy<T, V>(
+    fn: (x: T) => V,
+    ...rest: Array<void>
+  ): ((x: T, y: T) => T) & ((x: T) => (y: T) => T);
+  declare function maxBy<T, V>(
+    fn: (x: T) => V,
+    x: T,
+    ...rest: Array<void>
+  ): (y: T) => T;
+  declare function maxBy<T, V>(fn: (x: T) => V, x: T, y: T): T;
+
+  declare function min<T>(x: T, ...rest: Array<void>): (y: T) => T;
+  declare function min<T>(x: T, y: T): T;
+
+  declare function minBy<T, V>(
+    fn: (x: T) => V,
+    ...rest: Array<void>
+  ): ((x: T, y: T) => T) & ((x: T) => (y: T) => T);
+  declare function minBy<T, V>(
+    fn: (x: T) => V,
+    x: T,
+    ...rest: Array<void>
+  ): (y: T) => T;
+  declare function minBy<T, V>(fn: (x: T) => V, x: T, y: T): T;
+
+  declare function sortBy<T, V>(
+    fn: (x: T) => V,
+    ...rest: Array<void>
+  ): (x: Array<T>) => Array<T>;
+  declare function sortBy<T, V>(fn: (x: T) => V, x: Array<T>): Array<T>;
+
+  declare function symmetricDifference<T>(
+    x: Array<T>,
+    ...rest: Array<void>
+  ): (y: Array<T>) => Array<T>;
+  declare function symmetricDifference<T>(x: Array<T>, y: Array<T>): Array<T>;
+
+  declare function symmetricDifferenceWith<T>(
+    fn: BinaryPredicateFn<T>,
+    ...rest: Array<void>
+  ): ((x: Array<T>, ...rest: Array<void>) => (y: Array<T>) => Array<T>) &
+    ((x: Array<T>, y: Array<T>) => Array<T>);
+  declare function symmetricDifferenceWith<T>(
+    fn: BinaryPredicateFn<T>,
+    x: Array<T>,
+    ...rest: Array<void>
+  ): (y: Array<T>) => Array<T>;
+  declare function symmetricDifferenceWith<T>(
+    fn: BinaryPredicateFn<T>,
+    x: Array<T>,
+    y: Array<T>
+  ): Array<T>;
+
+  declare function union<T>(
+    x: Array<T>,
+    ...rest: Array<void>
+  ): (y: Array<T>) => Array<T>;
+  declare function union<T>(x: Array<T>, y: Array<T>): Array<T>;
+
+  declare function unionWith<T>(
+    fn: BinaryPredicateFn<T>,
+    ...rest: Array<void>
+  ): ((x: Array<T>, ...rest: Array<void>) => (y: Array<T>) => Array<T>) &
+    ((x: Array<T>, y: Array<T>) => Array<T>);
+  declare function unionWith<T>(
+    fn: BinaryPredicateFn<T>,
+    x: Array<T>,
+    ...rest: Array<void>
+  ): (y: Array<T>) => Array<T>;
+  declare function unionWith<T>(
+    fn: BinaryPredicateFn<T>,
+    x: Array<T>,
+    y: Array<T>
+  ): Array<T>;
+
+  // *Object
+  declare function assoc<T, S>(
+    key: string,
+    ...args: Array<void>
+  ): ((val: T, ...rest: Array<void>) => (src: S) => { [k: string]: T }) &
+    ((val: T, src: S) => { [k: string]: T } & S);
+  declare function assoc<T, S>(
+    key: string,
+    val: T,
+    ...args: Array<void>
+  ): (src: S) => { [k: string]: T } & S;
+  declare function assoc<T, S>(
+    key: string,
+    val: T,
+    src: S
+  ): { [k: string]: T } & S;
+
+  declare function assocPath<T, S>(
+    key: Array<string>,
+    ...args: Array<void>
+  ): ((val: T, ...rest: Array<void>) => (src: S) => { [k: string]: T }) &
+    ((val: T) => (src: S) => { [k: string]: T } & S);
+  declare function assocPath<T, S>(
+    key: Array<string>,
+    val: T,
+    ...args: Array<void>
+  ): (src: S) => { [k: string]: T } & S;
+  declare function assocPath<T, S>(
+    key: Array<string>,
+    val: T,
+    src: S
+  ): { [k: string]: T } & S;
+
+  declare function clone<T>(src: T): $Shape<T>;
+
+  declare function dissoc<T>(
+    key: string,
+    ...args: Array<void>
+  ): (src: { [k: string]: T }) => { [k: string]: T };
+  declare function dissoc<T>(
+    key: string,
+    src: { [k: string]: T }
+  ): { [k: string]: T };
+
+  declare function dissocPath<T>(
+    key: Array<string>,
+    ...args: Array<void>
+  ): (src: { [k: string]: T }) => { [k: string]: T };
+  declare function dissocPath<T>(
+    key: Array<string>,
+    src: { [k: string]: T }
+  ): { [k: string]: T };
+
+  // TODO: Started failing in v31... (Attempt to fix below)
+  // declare type __UnwrapNestedObjectR<T, U, V: NestedObject<(t: T) => U>> = U
+  // declare type UnwrapNestedObjectR<T> = UnwrapNestedObjectR<*, *, T>
+  //
+  // declare function evolve<R, T: NestedObject<(x:any) => R>>(fn: T, ...rest: Array<void>): (src: NestedObject<any>) => UnwrapNestedObjectR<T>;
+  // declare function evolve<R: NestedObject<(x:any) => R>>(fn: T, src: NestedObject<any>): UnwrapNestedObjectR<T>;
+
+  declare function eqProps(
+    key: string,
+    ...args: Array<void>
+  ): ((o1: Object, ...rest: Array<void>) => (o2: Object) => boolean) &
+    ((o1: Object, o2: Object) => boolean);
+  declare function eqProps(
+    key: string,
+    o1: Object,
+    ...args: Array<void>
+  ): (o2: Object) => boolean;
+  declare function eqProps(key: string, o1: Object, o2: Object): boolean;
+
+  declare function has(key: string, o: Object): boolean;
+  declare function has(key: string): (o: Object) => boolean;
+
+  declare function hasIn(key: string, o: Object): boolean;
+  declare function hasIn(key: string): (o: Object) => boolean;
+
+  declare function invert(o: Object): { [k: string]: Array<string> };
+  declare function invertObj(o: Object): { [k: string]: string };
+
+  declare function keys(o: Object): Array<string>;
+
+  /* TODO
+  lens
+  lensIndex
+  lensPath
+  lensProp
+  */
+
+  declare function mapObjIndexed<A, B>(
+    fn: (val: A, key: string, o: Object) => B,
+    o: { [key: string]: A }
+  ): { [key: string]: B };
+  declare function mapObjIndexed<A, B>(
+    fn: (val: A, key: string, o: Object) => B,
+    ...args: Array<void>
+  ): (o: { [key: string]: A }) => { [key: string]: B };
+
+  declare function merge<A, B>(o1: A, ...rest: Array<void>): (o2: B) => A & B;
+  declare function merge<A, B>(o1: A, o2: B): A & B;
+
+  declare function mergeAll<T>(
+    os: Array<{ [k: string]: T }>
+  ): { [k: string]: T };
+
+  declare function mergeWith<
+    T,
+    S,
+    R,
+    A: { [k: string]: T },
+    B: { [k: string]: S }
+  >(
+    fn: (v1: T, v2: S) => R
+  ): ((o1: A, ...rest: Array<void>) => (o2: B) => A & B) &
+    ((o1: A, o2: B) => A & B);
+  declare function mergeWith<
+    T,
+    S,
+    R,
+    A: { [k: string]: T },
+    B: { [k: string]: S }
+  >(
+    fn: (v1: T, v2: S) => R,
+    o1: A,
+    o2: B
+  ): A & B;
+  declare function mergeWith<
+    T,
+    S,
+    R,
+    A: { [k: string]: T },
+    B: { [k: string]: S }
+  >(
+    fn: (v1: T, v2: S) => R,
+    o1: A,
+    ...rest: Array<void>
+  ): (o2: B) => A & B;
+
+  declare function mergeWithKey<
+    T,
+    S,
+    R,
+    A: { [k: string]: T },
+    B: { [k: string]: S }
+  >(
+    fn: (key: $Keys<A & B>, v1: T, v2: S) => R
+  ): ((o1: A, ...rest: Array<void>) => (o2: B) => A & B) &
+    ((o1: A, o2: B) => A & B);
+  declare function mergeWithKey<
+    T,
+    S,
+    R,
+    A: { [k: string]: T },
+    B: { [k: string]: S }
+  >(
+    fn: (key: $Keys<A & B>, v1: T, v2: S) => R,
+    o1: A,
+    o2: B
+  ): A & B;
+  declare function mergeWithKey<
+    T,
+    S,
+    R,
+    A: { [k: string]: T },
+    B: { [k: string]: S }
+  >(
+    fn: (key: $Keys<A & B>, v1: T, v2: S) => R,
+    o1: A,
+    ...rest: Array<void>
+  ): (o2: B) => A & B;
+
+  declare function objOf<T>(
+    key: string,
+    ...rest: Array<void>
+  ): (val: T) => { [key: string]: T };
+  declare function objOf<T>(key: string, val: T): { [key: string]: T };
+
+  declare function omit<T: Object>(
+    keys: Array<$Keys<T>>,
+    ...rest: Array<void>
+  ): (val: T) => Object;
+  declare function omit<T: Object>(keys: Array<$Keys<T>>, val: T): Object;
+
+  // TODO over
+
+  declare function path<V>(
+    p: Array<mixed>,
+    ...rest: Array<void>
+  ): (o: NestedObject<V>) => V;
+  declare function path<V>(
+    p: Array<mixed>,
+    ...rest: Array<void>
+  ): (o: null | void) => void;
+  declare function path<V>(
+    p: Array<mixed>,
+    ...rest: Array<void>
+  ): (o: mixed) => ?V;
+  declare function path<V, A: NestedObject<V>>(p: Array<mixed>, o: A): V;
+  declare function path<V, A: null | void>(p: Array<mixed>, o: A): void;
+  declare function path<V, A: mixed>(p: Array<mixed>, o: A): ?V;
+
+  declare function path<V>(
+    p: Array<string>,
+    ...rest: Array<void>
+  ): (o: NestedObject<V>) => V;
+  declare function path<V>(
+    p: Array<string>,
+    ...rest: Array<void>
+  ): (o: null | void) => void;
+  declare function path<V>(
+    p: Array<string>,
+    ...rest: Array<void>
+  ): (o: mixed) => ?V;
+  declare function path<V, A: NestedObject<V>>(p: Array<string>, o: A): V;
+  declare function path<V, A: null | void>(p: Array<string>, o: A): void;
+  declare function path<V, A: mixed>(p: Array<string>, o: A): ?V;
+
+  declare function pathOr<T, V, A: NestedObject<V>>(
+    or: T,
+    ...rest: Array<void>
+  ): ((p: Array<string>, ...rest: Array<void>) => (o: ?A) => V | T) &
+    ((p: Array<string>, o: ?A) => V | T);
+  declare function pathOr<T, V, A: NestedObject<V>>(
+    or: T,
+    p: Array<string>,
+    ...rest: Array<void>
+  ): (o: ?A) => V | T;
+  declare function pathOr<T, V, A: NestedObject<V>>(
+    or: T,
+    p: Array<string>,
+    o: ?A
+  ): V | T;
+
+  declare function pick<A>(
+    keys: Array<string>,
+    ...rest: Array<void>
+  ): (val: { [key: string]: A }) => { [key: string]: A };
+  declare function pick<A>(
+    keys: Array<string>,
+    val: { [key: string]: A }
+  ): { [key: string]: A };
+
+  declare function pickAll<A>(
+    keys: Array<string>,
+    ...rest: Array<void>
+  ): (val: { [key: string]: A }) => { [key: string]: ?A };
+  declare function pickAll<A>(
+    keys: Array<string>,
+    val: { [key: string]: A }
+  ): { [key: string]: ?A };
+
+  declare function pickBy<A>(
+    fn: BinaryPredicateFn2<A, string>,
+    ...rest: Array<void>
+  ): (val: { [key: string]: A }) => { [key: string]: A };
+  declare function pickBy<A>(
+    fn: BinaryPredicateFn2<A, string>,
+    val: { [key: string]: A }
+  ): { [key: string]: A };
+
+  declare function project<T>(
+    keys: Array<string>,
+    ...rest: Array<void>
+  ): (val: Array<{ [key: string]: T }>) => Array<{ [key: string]: T }>;
+  declare function project<T>(
+    keys: Array<string>,
+    val: Array<{ [key: string]: T }>
+  ): Array<{ [key: string]: T }>;
+
+  declare function prop<T, O: { [k: string]: T }>(
+    key: $Keys<O>,
+    ...rest: Array<void>
+  ): (o: O) => ?T;
+  declare function prop<T, O: { [k: string]: T }>(
+    __: $npm$ramda$Placeholder,
+    o: O
+  ): (key: $Keys<O>) => ?T;
+  declare function prop<T, O: { [k: string]: T }>(key: $Keys<O>, o: O): ?T;
+
+  declare function propOr<T, V, A: { [k: string]: V }>(
+    or: T,
+    ...rest: Array<void>
+  ): ((p: $Keys<A>, ...rest: Array<void>) => (o: A) => V | T) &
+    ((p: $Keys<A>, o: A) => V | T);
+  declare function propOr<T, V, A: { [k: string]: V }>(
+    or: T,
+    p: $Keys<A>,
+    ...rest: Array<void>
+  ): (o: A) => V | T;
+  declare function propOr<T, V, A: { [k: string]: V }>(
+    or: T,
+    p: $Keys<A>,
+    o: A
+  ): V | T;
+
+  declare function keysIn(o: Object): Array<string>;
+
+  declare function props<T, O: { [k: string]: T }>(
+    keys: Array<$Keys<O>>,
+    ...rest: Array<void>
+  ): (o: O) => Array<?T>;
+  declare function props<T, O: { [k: string]: T }>(
+    keys: Array<$Keys<O>>,
+    o: O
+  ): Array<?T>;
+
+  // TODO set
+
+  declare function toPairs<T, O: { [k: string]: T }>(
+    o: O
+  ): Array<[$Keys<O>, T]>;
+
+  declare function toPairsIn<T, O: { [k: string]: T }>(
+    o: O
+  ): Array<[string, T]>;
+
+  declare function values<T, O: { [k: string]: T }>(o: O): Array<T>;
+
+  declare function valuesIn<T, O: { [k: string]: T }>(o: O): Array<T | any>;
+
+  declare function where<O>(
+    predObj: $ObjMap<O, MapUnaryPredicateFn>,
+    o: O
+  ): boolean;
+  declare function where<O>(
+    predObj: $ObjMap<O, MapUnaryPredicateFn>
+  ): O => boolean;
+
+  declare function whereEq<T, S, O: { [k: string]: T }, Q: { [k: string]: S }>(
+    predObj: O,
+    ...rest: Array<void>
+  ): (o: $Shape<O & Q>) => boolean;
+  declare function whereEq<T, S, O: { [k: string]: T }, Q: { [k: string]: S }>(
+    predObj: O,
+    o: $Shape<O & Q>
+  ): boolean;
+
+  // TODO view
+
+  // *Function
+  declare var __: $npm$ramda$Placeholder;
+
+  declare var T: (_: any) => true;
+  declare var F: (_: any) => false;
+
+  declare function addIndex<A, B>(
+    iterFn: (fn: (x: A) => B, xs: Array<A>) => Array<B>
+  ): (fn: (x: A, idx: number, xs: Array<A>) => B, xs: Array<A>) => Array<B>;
+
+  declare function always<T>(x: T): (x: any) => T;
+
+  declare function ap<T, V>(
+    fns: Array<(x: T) => V>,
+    ...rest: Array<void>
+  ): (xs: Array<T>) => Array<V>;
+  declare function ap<T, V>(fns: Array<(x: T) => V>, xs: Array<T>): Array<V>;
+
+  declare function apply<T, V>(
+    fn: (...args: Array<T>) => V,
+    ...rest: Array<void>
+  ): (xs: Array<T>) => V;
+  declare function apply<T, V>(fn: (...args: Array<T>) => V, xs: Array<T>): V;
+
+  declare function applySpec<
+    V,
+    S,
+    A: Array<V>,
+    T: NestedObject<(...args: A) => S>
+  >(
+    spec: T
+  ): (...args: A) => NestedObject<S>;
+
+  declare function binary<T>(
+    fn: (...args: Array<any>) => T
+  ): (x: any, y: any) => T;
+
+  declare function bind<T>(
+    fn: (...args: Array<any>) => any,
+    thisObj: T
+  ): (...args: Array<any>) => any;
+
+  declare function call<T, V>(
+    fn: (...args: Array<V>) => T,
+    ...args: Array<V>
+  ): T;
+
+  declare function comparator<T>(
+    fn: BinaryPredicateFn<T>
+  ): (x: T, y: T) => number;
+
+  // TODO add tests
+  declare function construct<T>(
+    ctor: Class<GenericContructor<T>>
+  ): (x: T) => GenericContructor<T>;
+
+  // TODO add tests
+  declare function constructN<T>(
+    n: number,
+    ctor: Class<GenericContructorMulti<any>>
+  ): (...args: any) => GenericContructorMulti<any>;
+
+  // TODO make less generic
+  declare function converge(after: Function, fns: Array<Function>): Function;
+
+  declare function empty<T>(x: T): T;
+
+  declare function flip<A, B, TResult>(
+    fn: (arg0: A, arg1: B) => TResult
+  ): CurriedFunction2<B, A, TResult>;
+  declare function flip<A, B, C, TResult>(
+    fn: (arg0: A, arg1: B, arg2: C) => TResult
+  ): ((arg0: B, arg1: A, ...rest: Array<void>) => (arg2: C) => TResult) &
+    ((arg0: B, arg1: A, arg2: C) => TResult);
+  declare function flip<A, B, C, D, TResult>(
+    fn: (arg0: A, arg1: B, arg2: C, arg3: D) => TResult
+  ): ((
+    arg1: B,
+    arg0: A,
+    ...rest: Array<void>
+  ) => (arg2: C, arg3: D) => TResult) &
+    ((arg1: B, arg0: A, arg2: C, arg3: D) => TResult);
+  declare function flip<A, B, C, D, E, TResult>(
+    fn: (arg0: A, arg1: B, arg2: C, arg3: D, arg4: E) => TResult
+  ): ((
+    arg1: B,
+    arg0: A,
+    ...rest: Array<void>
+  ) => (arg2: C, arg3: D, arg4: E) => TResult) &
+    ((arg1: B, arg0: A, arg2: C, arg3: D, arg4: E) => TResult);
+
+  declare function identity<T>(x: T): T;
+
+  declare function invoker<A, B, C, D, O: { [k: string]: Function }>(
+    arity: number,
+    name: $Enum<O>
+  ): CurriedFunction2<A, O, D> &
+    CurriedFunction3<A, B, O, D> &
+    CurriedFunction4<A, B, C, O, D>;
+
+  declare function juxt<T, S>(
+    fns: Array<(...args: Array<S>) => T>
+  ): (...args: Array<S>) => Array<T>;
+
+  // TODO lift
+
+  // TODO liftN
+
+  declare function memoize<A, B, T: (...args: Array<A>) => B>(fn: T): T;
+
+  declare function nAry<T>(
+    arity: number,
+    fn: (...args: Array<any>) => T
+  ): (...args: Array<any>) => T;
+
+  declare function nthArg<T>(n: number): (...args: Array<T>) => T;
+
+  declare function of<T>(x: T): Array<T>;
+
+  declare function once<A, B, T: (...args: Array<A>) => B>(fn: T): T;
+
+  declare var partial: Partial;
+  // TODO partialRight
+  // TODO pipeK
+  // TODO pipeP
+
+  declare function tap<T>(fn: (x: T) => any, ...rest: Array<void>): (x: T) => T;
+  declare function tap<T>(fn: (x: T) => any, x: T): T;
+
+  // TODO tryCatch
+
+  declare function unapply<T, V>(
+    fn: (xs: Array<T>) => V
+  ): (...args: Array<T>) => V;
+
+  declare function unary<T>(fn: (...args: Array<any>) => T): (x: any) => T;
+
+  declare var uncurryN: (<A, B, C>(2, (A) => B => C) => (A, B) => C) &
+    (<A, B, C, D>(3, (A) => B => C => D) => (A, B, C) => D) &
+    (<A, B, C, D, E>(4, (A) => B => C => D => E) => (A, B, C, D) => E) &
+    (<A, B, C, D, E, F>(
+      5,
+      (A) => B => C => D => E => F
+    ) => (A, B, C, D, E) => F) &
+    (<A, B, C, D, E, F, G>(
+      6,
+      (A) => B => C => D => E => F => G
+    ) => (A, B, C, D, E, F) => G) &
+    (<A, B, C, D, E, F, G, H>(
+      7,
+      (A) => B => C => D => E => F => G => H
+    ) => (A, B, C, D, E, F, G) => H) &
+    (<A, B, C, D, E, F, G, H, I>(
+      8,
+      (A) => B => C => D => E => F => G => H => I
+    ) => (A, B, C, D, E, F, G, H) => I);
+
+  //TODO useWith
+
+  declare function wrap<A, B, C, D, F: (...args: Array<A>) => B>(
+    fn: F,
+    fn2: (fn: F, ...args: Array<C>) => D
+  ): (...args: Array<A | C>) => D;
+
+  // *Logic
+
+  declare function allPass<T>(
+    fns: Array<(...args: Array<T>) => boolean>
+  ): (...args: Array<T>) => boolean;
+
+  declare function and(
+    x: boolean,
+    ...rest: Array<void>
+  ): (y: boolean) => boolean;
+  declare function and(x: boolean, y: boolean): boolean;
+
+  declare function anyPass<T>(
+    fns: Array<(...args: Array<T>) => boolean>
+  ): (...args: Array<T>) => boolean;
+
+  declare function both<T>(
+    x: (...args: Array<T>) => boolean,
+    ...rest: Array<void>
+  ): (y: (...args: Array<T>) => boolean) => (...args: Array<T>) => boolean;
+  declare function both<T>(
+    x: (...args: Array<T>) => boolean,
+    y: (...args: Array<T>) => boolean
+  ): (...args: Array<T>) => boolean;
+
+  declare function complement<T>(
+    x: (...args: Array<T>) => boolean
+  ): (...args: Array<T>) => boolean;
+
+  declare function cond<A, B>(
+    fns: Array<[(...args: Array<A>) => boolean, (...args: Array<A>) => B]>
+  ): (...args: Array<A>) => B;
+
+  declare function defaultTo<T, V>(
+    d: T,
+    ...rest: Array<void>
+  ): (x: ?V) => V | T;
+  declare function defaultTo<T, V>(d: T, x: ?V): V | T;
+
+  declare function either(
+    x: (...args: Array<any>) => *,
+    ...rest: Array<void>
+  ): (y: (...args: Array<any>) => *) => (...args: Array<any>) => *;
+  declare function either(
+    x: (...args: Array<any>) => *,
+    y: (...args: Array<any>) => *
+  ): (...args: Array<any>) => *;
+
+  declare function ifElse<A, B, C>(
+    cond: (...args: Array<A>) => boolean,
+    ...rest: Array<void>
+  ): ((
+    f1: (...args: Array<A>) => B,
+    ...rest: Array<void>
+  ) => (f2: (...args: Array<A>) => C) => (...args: Array<A>) => B | C) &
+    ((
+      f1: (...args: Array<A>) => B,
+      f2: (...args: Array<A>) => C
+    ) => (...args: Array<A>) => B | C);
+  declare function ifElse<A, B, C>(
+    cond: (...args: Array<any>) => boolean,
+    f1: (...args: Array<any>) => B,
+    f2: (...args: Array<any>) => C
+  ): (...args: Array<A>) => B | C;
+
+  declare function isEmpty(x: ?Array<any> | Object | string): boolean;
+
+  declare function not(x: boolean): boolean;
+
+  declare function or(x: boolean, y: boolean): boolean;
+  declare function or(x: boolean): (y: boolean) => boolean;
+
+  declare var pathSatisfies: CurriedFunction3<
+    UnaryPredicateFn<any>,
+    string[],
+    Object,
+    boolean
+  >;
+
+  declare function propSatisfies<T>(
+    cond: (x: T) => boolean,
+    prop: string,
+    o: NestedObject<T>
+  ): boolean;
+  declare function propSatisfies<T>(
+    cond: (x: T) => boolean,
+    prop: string,
+    ...rest: Array<void>
+  ): (o: NestedObject<T>) => boolean;
+  declare function propSatisfies<T>(
+    cond: (x: T) => boolean,
+    ...rest: Array<void>
+  ): ((prop: string, ...rest: Array<void>) => (o: NestedObject<T>) => boolean) &
+    ((prop: string, o: NestedObject<T>) => boolean);
+
+  declare function unless<T, V, S>(
+    pred: UnaryPredicateFn<T>,
+    ...rest: Array<void>
+  ): ((fn: (x: S) => V, ...rest: Array<void>) => (x: T | S) => T | V) &
+    ((fn: (x: S) => V, x: T | S) => T | V);
+  declare function unless<T, V, S>(
+    pred: UnaryPredicateFn<T>,
+    fn: (x: S) => V,
+    ...rest: Array<void>
+  ): (x: T | S) => V | T;
+  declare function unless<T, V, S>(
+    pred: UnaryPredicateFn<T>,
+    fn: (x: S) => V,
+    x: T | S
+  ): T | V;
+
+  declare function until<T>(
+    pred: UnaryPredicateFn<T>,
+    ...rest: Array<void>
+  ): ((fn: (x: T) => T, ...rest: Array<void>) => (x: T) => T) &
+    ((fn: (x: T) => T, x: T) => T);
+  declare function until<T>(
+    pred: UnaryPredicateFn<T>,
+    fn: (x: T) => T,
+    ...rest: Array<void>
+  ): (x: T) => T;
+  declare function until<T>(
+    pred: UnaryPredicateFn<T>,
+    fn: (x: T) => T,
+    x: T
+  ): T;
+
+  declare function when<T, V, S>(
+    pred: UnaryPredicateFn<T>,
+    ...rest: Array<void>
+  ): ((fn: (x: S) => V, ...rest: Array<void>) => (x: T | S) => T | V) &
+    ((fn: (x: S) => V, x: T | S) => T | V);
+  declare function when<T, V, S>(
+    pred: UnaryPredicateFn<T>,
+    fn: (x: S) => V,
+    ...rest: Array<void>
+  ): (x: T | S) => V | T;
+  declare function when<T, V, S>(
+    pred: UnaryPredicateFn<T>,
+    fn: (x: S) => V,
+    x: T | S
+  ): T | V;
+}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "istanbul": "^0.4.5",
     "mocha": "^3.2.0",
     "nyc": "^11.0.2",
+    "ramda": "^0.25.0",
     "rollup": "^0.47.4",
     "rollup-plugin-babel": "^3.0.1"
   },
@@ -29,7 +30,11 @@
     "build": "rollup -c",
     "prepublishOnly": "rm -r dist && yarn build"
   },
-  "keywords": ["schema", "validator", "validation"],
+  "keywords": [
+    "schema",
+    "validator",
+    "validation"
+  ],
   "contributors": [
     {
       "name": "Elliot Davies",
@@ -53,8 +58,13 @@
   },
   "homepage": "https://github.com/times/data-validator#readme",
   "nyc": {
-    "require": ["babel-register"],
-    "reporter": ["lcov", "text"],
+    "require": [
+      "babel-register"
+    ],
+    "reporter": [
+      "lcov",
+      "text"
+    ],
     "sourceMap": false,
     "instrument": false
   }

--- a/package.json
+++ b/package.json
@@ -1,40 +1,17 @@
 {
   "name": "@times/data-validator",
-  "version": "0.5.5",
+  "version": "0.6.0",
   "description": "Simple, composable data validator for JavaScript",
   "main": "dist/index.umd.js",
   "module": "dist/index.esm.js",
-  "dependencies": {
-    "babel-plugin-external-helpers": "^6.22.0"
-  },
-  "devDependencies": {
-    "babel-cli": "^6.24.1",
-    "babel-core": "^6.25.0",
-    "babel-plugin-istanbul": "^4.1.4",
-    "babel-plugin-transform-flow-strip-types": "^6.22.0",
-    "babel-plugin-transform-object-rest-spread": "^6.23.0",
-    "babel-preset-es2015": "^6.24.1",
-    "babelrc-rollup": "^3.0.0",
-    "chai": "^3.5.0",
-    "flow-bin": "^0.48.0",
-    "istanbul": "^0.4.5",
-    "mocha": "^3.2.0",
-    "nyc": "^11.0.2",
-    "ramda": "^0.25.0",
-    "rollup": "^0.47.4",
-    "rollup-plugin-babel": "^3.0.1"
-  },
   "scripts": {
-    "test": "NODE_ENV=test nyc mocha ./test",
     "flow": "flow",
-    "build": "rollup -c",
+    "lint": "eslint ./src",
+    "test": "NODE_ENV=test nyc mocha ./test",
+    "build": "yarn flow && yarn lint && yarn test && rollup -c",
     "prepublishOnly": "rm -r dist && yarn build"
   },
-  "keywords": [
-    "schema",
-    "validator",
-    "validation"
-  ],
+  "keywords": ["schema", "validator", "validation"],
   "contributors": [
     {
       "name": "Elliot Davies",
@@ -57,14 +34,33 @@
     "url": "https://github.com/times/data-validator/issues"
   },
   "homepage": "https://github.com/times/data-validator#readme",
+  "dependencies": {
+    "babel-plugin-external-helpers": "^6.22.0"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.24.1",
+    "babel-core": "^6.25.0",
+    "babel-eslint": "^8.2.2",
+    "babel-plugin-istanbul": "^4.1.4",
+    "babel-plugin-transform-flow-strip-types": "^6.22.0",
+    "babel-plugin-transform-object-rest-spread": "^6.23.0",
+    "babel-preset-es2015": "^6.24.1",
+    "babelrc-rollup": "^3.0.0",
+    "chai": "^3.5.0",
+    "eslint": "^4.18.2",
+    "eslint-plugin-flowtype": "^2.46.1",
+    "eslint-plugin-promise": "^3.6.0",
+    "flow-bin": "^0.48.0",
+    "istanbul": "^0.4.5",
+    "mocha": "^3.2.0",
+    "nyc": "^11.0.2",
+    "ramda": "^0.25.0",
+    "rollup": "^0.47.4",
+    "rollup-plugin-babel": "^3.0.1"
+  },
   "nyc": {
-    "require": [
-      "babel-register"
-    ],
-    "reporter": [
-      "lcov",
-      "text"
-    ],
+    "require": ["babel-register"],
+    "reporter": ["lcov", "text"],
     "sourceMap": false,
     "instrument": false
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+// @flow
 export { all, allWhileOK, some } from './lib/compose';
 
 export { printVerbose, getErrors } from './lib/printer';
@@ -39,10 +40,12 @@ export {
   validateIsIn,
   validateIsObject,
   validateObjHasKey,
+  validateObjFields,
   validateObjPropHasType,
   validateObjPropPasses,
   validateObjOnlyHasKeys,
   validateIsArray,
+  validateArrayItems,
   validateArrayItemsHaveType,
   validateArrayItemsPass
 } from './lib/validators';

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,15 @@
 export { all, allWhileOK, some } from './lib/compose';
 
+export { printVerbose, getErrors } from './lib/printer';
+
 export {
   ok,
   err,
   isOK,
   isErr,
-  toResult,
   mapErrors,
-  prefixErrors,
-  flattenResults,
-  getErrors,
+  mergeResults,
+  concatResults
 } from './lib/result';
 
 export {
@@ -19,7 +19,7 @@ export {
   fromObjectSchemaStrict,
   fromArraySchema,
   objectValidator,
-  arrayValidator,
+  arrayValidator
 } from './lib/schema';
 
 export {
@@ -27,7 +27,8 @@ export {
   isDate,
   isObject,
   isArray,
-  isType,
+  isNull,
+  isType
 } from './lib/typecheck';
 
 export {
@@ -43,5 +44,5 @@ export {
   validateObjOnlyHasKeys,
   validateIsArray,
   validateArrayItemsHaveType,
-  validateArrayItemsPass,
+  validateArrayItemsPass
 } from './lib/validators';

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ export {
   isErr,
   mapErrors,
   mergeResults,
-  concatResults
+  concatResults,
 } from './lib/result';
 
 export {
@@ -20,7 +20,7 @@ export {
   fromObjectSchemaStrict,
   fromArraySchema,
   objectValidator,
-  arrayValidator
+  arrayValidator,
 } from './lib/schema';
 
 export {
@@ -29,7 +29,7 @@ export {
   isObject,
   isArray,
   isNull,
-  isType
+  isType,
 } from './lib/typecheck';
 
 export {
@@ -47,5 +47,4 @@ export {
   validateIsArray,
   validateArrayItems,
   validateArrayItemsHaveType,
-  validateArrayItemsPass
 } from './lib/validators';

--- a/src/lib/compose.js
+++ b/src/lib/compose.js
@@ -29,8 +29,8 @@ export const all: Composer = validators => data =>
  * succeed. Otherwise, returns all of the errors
  */
 export const some: Composer = validators => data =>
-  validators.reduce((res, v) => {
+  reduce((res, v) => {
     if (isOK(res)) return res;
     const vRes = v(data);
     return isErr(vRes) ? mergeResults(res, vRes) : vRes;
-  }, err());
+  }, err())(validators);

--- a/src/lib/compose.js
+++ b/src/lib/compose.js
@@ -1,7 +1,7 @@
 // @flow
 import { map, reduce } from 'ramda';
 
-import { isOK, ok, isErr, err, concatResults, mergeResults } from './result';
+import { concatResults, err, isOK, ok, mergeResults } from './result';
 import type { Result } from './result';
 import type { Validator, Data } from './validators';
 
@@ -33,5 +33,5 @@ export const some: Composer = validators => data =>
   reduce((res, v) => {
     if (isOK(res)) return res;
     const vRes = v(data);
-    return isErr(vRes) ? mergeResults(res, vRes) : vRes;
+    return isOK(vRes) ? vRes : mergeResults(res, vRes);
   }, err())(validators);

--- a/src/lib/compose.js
+++ b/src/lib/compose.js
@@ -6,27 +6,28 @@ import type { Result } from './result';
 import type { Validator, Data } from './validators';
 
 /**
- * Types
+ * A Composer accepts an array of Validators and applies some Data to each of
+ * them in turn according to its particular logic, returning a single Result
  */
 type Composer = (Array<Validator>) => Data => Result;
 
 /**
- * Run a series of validators (left-to-right) such that all of the
- * validators must succeed. Otherwise, returns the first set of errors
+ * Runs an array of validators in order until one of them returns an Err.
+ * If all of the validators succeed, returns an OK
  */
 export const allWhileOK: Composer = validators => data =>
   reduce((res, v) => (isOK(res) ? v(data) : res), ok())(validators);
 
 /**
- * Run a series of validators such that all of the validators
- * must succeed. Otherwise, returns all of the errors
+ * Runs all the validators in an array, returning their combined Errs. If all
+ * of the validators succeed, returns an OK
  */
 export const all: Composer = validators => data =>
   concatResults(map(v => v(data), validators));
 
 /**
- * Run a series of validators such that at least one of the validators must
- * succeed. Otherwise, returns all of the errors
+ * Runs all the validators in an array until one of them returns an OK. If all
+ * of the validators fail, returns their combined Errs
  */
 export const some: Composer = validators => data =>
   reduce((res, v) => {

--- a/src/lib/printer.js
+++ b/src/lib/printer.js
@@ -1,18 +1,113 @@
 // @flow
-import { mapObjIndexed as mapObj, map, flatten, concat, values } from 'ramda';
+import {
+  mapObjIndexed as mapObj,
+  map,
+  reduce,
+  flatten,
+  concat,
+  values,
+  mergeWith
+} from 'ramda';
 
-type AST = {|
-  type: string,
+type Error = string;
+type Errors = Array<Error>;
+
+type Ok = { valid: true };
+
+type Err = {|
+  valid: false,
   value: mixed,
-  errors: Array<string>,
+  errors: Errors,
+  type?: string,
   items?: {
-    [string]: AST
+    [string]: Result
   }
 |};
 
+type Result = Ok | Err;
+
+type Validator = any => Result;
+
+// Helpers
+type _ok = () => Result;
+export const ok: _ok = () => ({ valid: true });
+
+type _err = (mixed, Error) => Result;
+export const err: _err = (value, error) => ({
+  valid: false,
+  value,
+  errors: [error]
+});
+
+type IsOK = Result => boolean;
+export const isOK: IsOK = ({ valid }) => valid;
+
+type IsErr = Result => boolean;
+export const isErr: IsErr = ({ valid }) => !valid;
+
+type MergeResults = (Result, Result) => Result;
+export const mergeResults: MergeResults = (r1, r2) => {
+  if (r1.valid) return r2;
+  if (r2.valid) return r1;
+
+  const r1Items = r1.items || {};
+  const r2Items = r2.items || {};
+
+  // Otherwise merge errors
+  return {
+    valid: false,
+    value: r1.value,
+    errors: concat(r1.errors, r2.errors), // intersection?
+    type: r1.type,
+    items: mergeWith(mergeResults, r1Items, r2Items)
+  };
+};
+
+type ConcatResults = (Array<Result>) => Result;
+export const concatResults: ConcatResults = reduce(mergeResults, ok());
+
+// Apply a function to every error in a Result
+type MapErrors = ((string) => string) => Result => Result;
+export const mapErrors: MapErrors = f => r => {
+  if (r.valid) return r;
+
+  const mappedErrors = map(f, r.errors);
+
+  return r.items
+    ? {
+        ...r,
+        errors: mappedErrors,
+        items: map(mapErrors(f), r.items)
+      }
+    : {
+        ...r,
+        errors: mappedErrors
+      };
+};
+
+// Composers
+type Composer = (Array<Validator>) => any => Result;
+
+export const allWhileOK: Composer = validators => data =>
+  reduce((res, v) => (isOK(res) ? v(data) : res), ok())(validators);
+
+export const all: Composer = validators => data =>
+  concatResults(map(v => v(data), validators));
+
+// Validators
+export const valStrLen: Validator = s =>
+  s.length > 5 ? ok() : err(s, 'Length < 5');
+
+export const valStrStartsWith: string => Validator = c => s =>
+  s.charAt(0) === c ? ok() : err(s, `Expected ${c} (got ${s.charAt(0)})`);
+
+export const valStr: Validator = allWhileOK([valStrLen, valStrStartsWith('A')]);
+
 // Verbose
-type PrintVerboseHelper = boolean => AST => Array<string>;
+type PrintVerboseHelper = boolean => Result => Errors;
 const printVerboseHelper: PrintVerboseHelper = isNested => ast => {
+  if (ast.valid) return [];
+
   const { items = {}, errors, type } = ast;
 
   const withPrefix = key => err => {
@@ -34,5 +129,9 @@ const printVerboseHelper: PrintVerboseHelper = isNested => ast => {
   return concat(errors, flatten(values(nestedErrors)));
 };
 
-type PrintVerbose = AST => Array<string>;
+type PrintVerbose = Result => Errors;
 export const printVerbose: PrintVerbose = printVerboseHelper(false);
+
+// Retrieve errors
+type GetErrors = Result => Errors;
+export const getErrors: GetErrors = printVerbose;

--- a/src/lib/printer.js
+++ b/src/lib/printer.js
@@ -1,0 +1,42 @@
+// @flow
+import { mapObjIndexed as mapObj, map, flatten, concat, values } from 'ramda';
+
+type AST = {|
+  type: string,
+  value: any,
+  errors: Array<string>,
+  items?: {
+    [string]: AST
+  }
+|};
+
+type Context = {
+  parentType?: string,
+  itemKey?: string
+};
+
+// Verbose
+type PrintVerboseHelper = boolean => AST => Array<string>;
+const printVerboseHelper: PrintVerboseHelper = isNested => ast => {
+  const { items = {}, errors, type } = ast;
+
+  const withPrefix = key => err => {
+    const at = isNested ? 'at' : 'At';
+
+    const prefix =
+      type === 'array'
+        ? `${at} item ${key}: `
+        : type === 'object' ? `${at} field ${key}: ` : ``;
+
+    return prefix + err;
+  };
+
+  const nestedErrors = mapObj((v, k) =>
+    map(withPrefix(k))(printVerboseHelper(true)(v))
+  )(items);
+
+  return concat(errors)(flatten(values(nestedErrors)));
+};
+
+type PrintVerbose = AST => Array<string>;
+export const printVerbose: PrintVerbose = printVerboseHelper(false);

--- a/src/lib/printer.js
+++ b/src/lib/printer.js
@@ -3,12 +3,22 @@ import { concat, flatten, map, mapObjIndexed as mapObj, values } from 'ramda';
 
 import type { Result, Errors } from './result';
 
-// Verbose
-type PrintVerboseHelper = boolean => Result => Errors;
-const printVerboseHelper: PrintVerboseHelper = isNested => ast => {
-  if (ast.valid) return [];
+/**
+ * A Printer accepts a Result and "pretty prints" it, turning it into an array
+ * of formatted error messages
+ */
+type Printer = Result => Errors;
 
-  const { items = {}, errors, type } = ast;
+/**
+ * Print errors from a Result in a verbose format e.g.
+ *
+ *  `At item 0: at field "a": 123 failed to typecheck (expected string)`
+ */
+type PrintVerboseHelper = boolean => Printer;
+const printVerboseHelper: PrintVerboseHelper = isNested => result => {
+  if (result.valid) return [];
+
+  const { items = {}, errors, type } = result;
 
   const withPrefix = key => err => {
     const at = isNested ? 'at' : 'At';
@@ -29,9 +39,9 @@ const printVerboseHelper: PrintVerboseHelper = isNested => ast => {
   return concat(errors, flatten(values(nestedErrors)));
 };
 
-type PrintVerbose = Result => Errors;
-export const printVerbose: PrintVerbose = printVerboseHelper(false);
+export const printVerbose: Printer = printVerboseHelper(false);
 
-// Retrieve errors from a result
-type GetErrors = Result => Errors;
-export const getErrors: GetErrors = printVerbose;
+/**
+ * Alias of printVerbose
+ */
+export const getErrors: Printer = printVerbose;

--- a/src/lib/printer.js
+++ b/src/lib/printer.js
@@ -3,17 +3,12 @@ import { mapObjIndexed as mapObj, map, flatten, concat, values } from 'ramda';
 
 type AST = {|
   type: string,
-  value: any,
+  value: mixed,
   errors: Array<string>,
   items?: {
     [string]: AST
   }
 |};
-
-type Context = {
-  parentType?: string,
-  itemKey?: string
-};
 
 // Verbose
 type PrintVerboseHelper = boolean => AST => Array<string>;
@@ -31,11 +26,12 @@ const printVerboseHelper: PrintVerboseHelper = isNested => ast => {
     return prefix + err;
   };
 
-  const nestedErrors = mapObj((v, k) =>
-    map(withPrefix(k))(printVerboseHelper(true)(v))
-  )(items);
+  const nestedErrors = mapObj(
+    (v, k) => map(withPrefix(k), printVerboseHelper(true)(v)),
+    items
+  );
 
-  return concat(errors)(flatten(values(nestedErrors)));
+  return concat(errors, flatten(values(nestedErrors)));
 };
 
 type PrintVerbose = AST => Array<string>;

--- a/src/lib/printer.js
+++ b/src/lib/printer.js
@@ -16,7 +16,7 @@ const printVerboseHelper: PrintVerboseHelper = isNested => ast => {
     const prefix =
       type === 'array'
         ? `${at} item ${key}: `
-        : type === 'object' ? `${at} field ${key}: ` : ``;
+        : type === 'object' ? `${at} field "${key}": ` : ``;
 
     return prefix + err;
   };

--- a/src/lib/printer.js
+++ b/src/lib/printer.js
@@ -1,5 +1,5 @@
 // @flow
-import { mapObjIndexed as mapObj, map, flatten, concat, values } from 'ramda';
+import { concat, flatten, map, mapObjIndexed as mapObj, values } from 'ramda';
 
 import type { Result, Errors } from './result';
 

--- a/src/lib/printer.js
+++ b/src/lib/printer.js
@@ -1,107 +1,7 @@
 // @flow
-import {
-  mapObjIndexed as mapObj,
-  map,
-  reduce,
-  flatten,
-  concat,
-  values,
-  mergeWith
-} from 'ramda';
+import { mapObjIndexed as mapObj, map, flatten, concat, values } from 'ramda';
 
-type Error = string;
-type Errors = Array<Error>;
-
-type Ok = { valid: true };
-
-type Err = {|
-  valid: false,
-  value: mixed,
-  errors: Errors,
-  type?: string,
-  items?: {
-    [string]: Result
-  }
-|};
-
-type Result = Ok | Err;
-
-type Validator = any => Result;
-
-// Helpers
-type _ok = () => Result;
-export const ok: _ok = () => ({ valid: true });
-
-type _err = (mixed, Error) => Result;
-export const err: _err = (value, error) => ({
-  valid: false,
-  value,
-  errors: [error]
-});
-
-type IsOK = Result => boolean;
-export const isOK: IsOK = ({ valid }) => valid;
-
-type IsErr = Result => boolean;
-export const isErr: IsErr = ({ valid }) => !valid;
-
-type MergeResults = (Result, Result) => Result;
-export const mergeResults: MergeResults = (r1, r2) => {
-  if (r1.valid) return r2;
-  if (r2.valid) return r1;
-
-  const r1Items = r1.items || {};
-  const r2Items = r2.items || {};
-
-  // Otherwise merge errors
-  return {
-    valid: false,
-    value: r1.value,
-    errors: concat(r1.errors, r2.errors), // intersection?
-    type: r1.type,
-    items: mergeWith(mergeResults, r1Items, r2Items)
-  };
-};
-
-type ConcatResults = (Array<Result>) => Result;
-export const concatResults: ConcatResults = reduce(mergeResults, ok());
-
-// Apply a function to every error in a Result
-type MapErrors = ((string) => string) => Result => Result;
-export const mapErrors: MapErrors = f => r => {
-  if (r.valid) return r;
-
-  const mappedErrors = map(f, r.errors);
-
-  return r.items
-    ? {
-        ...r,
-        errors: mappedErrors,
-        items: map(mapErrors(f), r.items)
-      }
-    : {
-        ...r,
-        errors: mappedErrors
-      };
-};
-
-// Composers
-type Composer = (Array<Validator>) => any => Result;
-
-export const allWhileOK: Composer = validators => data =>
-  reduce((res, v) => (isOK(res) ? v(data) : res), ok())(validators);
-
-export const all: Composer = validators => data =>
-  concatResults(map(v => v(data), validators));
-
-// Validators
-export const valStrLen: Validator = s =>
-  s.length > 5 ? ok() : err(s, 'Length < 5');
-
-export const valStrStartsWith: string => Validator = c => s =>
-  s.charAt(0) === c ? ok() : err(s, `Expected ${c} (got ${s.charAt(0)})`);
-
-export const valStr: Validator = allWhileOK([valStrLen, valStrStartsWith('A')]);
+import type { Result, Errors } from './result';
 
 // Verbose
 type PrintVerboseHelper = boolean => Result => Errors;
@@ -132,6 +32,6 @@ const printVerboseHelper: PrintVerboseHelper = isNested => ast => {
 type PrintVerbose = Result => Errors;
 export const printVerbose: PrintVerbose = printVerboseHelper(false);
 
-// Retrieve errors
+// Retrieve errors from a result
 type GetErrors = Result => Errors;
 export const getErrors: GetErrors = printVerbose;

--- a/src/lib/result.js
+++ b/src/lib/result.js
@@ -42,11 +42,6 @@ export const isOK: IsOK = ({ valid }) => valid !== undefined && valid;
 type IsErr = Result => boolean;
 export const isErr: IsErr = ({ valid }) => valid !== undefined && !valid;
 
-// Convert a (possibly empty) array of errors into a Result
-type ToResult = Errors => Result;
-export const toResult: ToResult = errs =>
-  errs.length === 0 ? ok() : err(errs);
-
 // Apply a function to every error in a Result
 type MapErrors = ((string, ?number) => string) => Result => Result;
 export const mapErrors: MapErrors = f => r => {
@@ -61,11 +56,6 @@ export const mapErrors: MapErrors = f => r => {
     ? merge(withMappedErrors, { items: map(mapErrors(f), r.items) })
     : withMappedErrors;
 };
-
-// Prefix every error in a Result with the given string
-type PrefixErrors = string => Result => Result;
-export const prefixErrors: PrefixErrors = prefix =>
-  mapErrors(e => `${prefix}${e}`);
 
 // Combine two results
 type MergeResults = (Result, Result) => Result;

--- a/src/lib/result.js
+++ b/src/lib/result.js
@@ -8,13 +8,15 @@ export type Errors = Array<string>;
 
 type OK = {| valid: true |};
 
+type Items = {
+  [string]: Result
+};
+
 type Err = {|
   valid: false,
   errors: Errors,
   type?: string,
-  items?: {
-    [string]: Result
-  }
+  items?: Items
 |};
 
 export type Result = OK | Err;
@@ -25,8 +27,11 @@ export type Result = OK | Err;
 type _ok = () => OK;
 export const ok: _ok = () => ({ valid: true });
 
-type _err = (errors?: Errors) => Result;
-export const err: _err = (errors = []) => ({ valid: false, errors });
+type _err = (errors?: Errors, type?: string, items?: Items) => Result;
+export const err: _err = (errors = [], type, items) =>
+  items && type
+    ? { valid: false, errors, type, items }
+    : { valid: false, errors };
 
 /**
  * Helpers

--- a/src/lib/result.js
+++ b/src/lib/result.js
@@ -38,10 +38,11 @@ export const ok: _ok = () => ({ valid: true });
  */
 type _err = (errors?: string | Errors, type?: ErrType, items?: Items) => Result;
 export const err: _err = (errors = [], type, items) => {
-  const errorList = Array.isArray(errors) ? errors : [errors];
-  return items && type
-    ? { valid: false, errors: errorList, type, items }
-    : { valid: false, errors: errorList };
+  const result = {
+    valid: false,
+    errors: Array.isArray(errors) ? errors : [errors]
+  };
+  return items && type ? merge(result, { type, items }) : result;
 };
 
 /**
@@ -83,17 +84,18 @@ export const mergeResults: MergeResults = (r1, r2) => {
   if (r1.valid) return r2;
   if (r2.valid) return r1;
 
-  // @TODO this will cause an `items` key to exist where it didn't before
-  const r1Items = r1.items || {};
-  const r2Items = r2.items || {};
-
   // Otherwise merge the errors
-  return {
+  const result = {
     valid: false,
     errors: concat(r1.errors, r2.errors),
-    type: r1.type,
-    items: mergeWith(mergeResults, r1Items, r2Items)
+    type: r1.type
   };
+
+  return r1.items || r2.items
+    ? merge(result, {
+        items: mergeWith(mergeResults, r1.items || {}, r2.items || {})
+      })
+    : result;
 };
 
 /**

--- a/src/lib/result.js
+++ b/src/lib/result.js
@@ -1,5 +1,13 @@
 // @flow
-import { addIndex, concat, map, merge, mergeWith, reduce } from 'ramda';
+import {
+  addIndex,
+  concat,
+  map,
+  mapObjIndexed as mapObj,
+  merge,
+  mergeWith,
+  reduce,
+} from 'ramda';
 
 /**
  * Error messages are represented as strings
@@ -68,7 +76,7 @@ export const isErr: IsErr = ({ valid }) => valid === false;
 /**
  * Applies a function to every error in a Result
  */
-type MapErrors = ((string, ?number) => string) => Result => Result;
+type MapErrors = ((string, number) => string) => Result => Result;
 export const mapErrors: MapErrors = f => r => {
   if (r.valid) return r;
 
@@ -78,7 +86,7 @@ export const mapErrors: MapErrors = f => r => {
   };
 
   return r.items
-    ? merge(withMappedErrors, { items: map(mapErrors(f), r.items) })
+    ? merge(withMappedErrors, { items: mapObj(mapErrors(f), r.items) })
     : withMappedErrors;
 };
 

--- a/src/lib/result.js
+++ b/src/lib/result.js
@@ -1,12 +1,21 @@
 // @flow
+import { addIndex, concat, map, merge, mergeWith, reduce } from 'ramda';
 
 /**
  * Types
  */
 export type Errors = Array<string>;
 
-type OK = { valid: true, errors: [] };
-type Err = { valid: false, errors: Errors };
+type OK = {| valid: true |};
+
+type Err = {|
+  valid: false,
+  errors: Errors,
+  type?: string,
+  items?: {
+    [string]: Result
+  }
+|};
 
 export type Result = OK | Err;
 
@@ -14,44 +23,57 @@ export type Result = OK | Err;
  * Constructors
  */
 type _ok = () => OK;
-export const ok: _ok = () => ({ valid: true, errors: [] });
+export const ok: _ok = () => ({ valid: true });
 
-type _err = (errs?: Errors) => Err;
-export const err: _err = (errs = []) => ({ valid: false, errors: errs });
+type _err = (errors?: Errors) => Result;
+export const err: _err = (errors = []) => ({ valid: false, errors });
 
 /**
  * Helpers
  */
 type IsOK = Result => boolean;
-export const isOK: IsOK = r => r.valid === true;
+export const isOK: IsOK = ({ valid }) => valid !== undefined && valid;
 
 type IsErr = Result => boolean;
-export const isErr: IsErr = r => r.valid === false;
-
-// Convert a (possibly empty) array of errors into a Result
-type ToResult = Errors => Result;
-export const toResult: ToResult = errs =>
-  errs.length === 0 ? ok() : err(errs);
+export const isErr: IsErr = ({ valid }) => valid !== undefined && !valid;
 
 // Apply a function to every error in a Result
-type MapErrors = ((string) => string) => Result => Result;
-export const mapErrors: MapErrors = f => r => toResult(r.errors.map(f));
+type MapErrors = ((string, ?number) => string) => Result => Result;
+export const mapErrors: MapErrors = f => r => {
+  if (r.valid) return r;
+
+  const withMappedErrors = {
+    valid: false,
+    errors: addIndex(map)(f, r.errors)
+  };
+
+  return r.items
+    ? merge(withMappedErrors, { items: map(mapErrors(f), r.items) })
+    : withMappedErrors;
+};
 
 // Prefix every error in a Result with the given string
 type PrefixErrors = string => Result => Result;
 export const prefixErrors: PrefixErrors = prefix =>
   mapErrors(e => `${prefix}${e}`);
 
-// Flatten an array of Results into a single Result
-type FlattenResults = (Array<Result>) => Result;
-export const flattenResults: FlattenResults = results =>
-  results.reduce(
-    (acc, r) =>
-      isErr(acc) || isErr(r) ? err([...getErrors(acc), ...getErrors(r)]) : ok(),
-    ok()
-  );
+// Combine two results
+type MergeResults = (Result, Result) => Result;
+export const mergeResults: MergeResults = (r1, r2) => {
+  if (r1.valid) return r2;
+  if (r2.valid) return r1;
 
-// Get the errors from a result
-type GetErrors = Result => Errors;
-export const getErrors: GetErrors = (result: Result) =>
-  isErr(result) ? [...result.errors] : [];
+  const r1Items = r1.items || {};
+  const r2Items = r2.items || {};
+
+  // Otherwise merge errors
+  return {
+    valid: false,
+    errors: concat(r1.errors, r2.errors), // intersection?
+    type: r1.type,
+    items: mergeWith(mergeResults, r1Items, r2Items)
+  };
+};
+
+type ConcatResults = (Array<Result>) => Result;
+export const concatResults: ConcatResults = reduce(mergeResults, ok());

--- a/src/lib/result.js
+++ b/src/lib/result.js
@@ -36,11 +36,13 @@ export const ok: _ok = () => ({ valid: true });
 /**
  * Constructs an Err result
  */
-type _err = (errors?: Errors, type?: ErrType, items?: Items) => Result;
-export const err: _err = (errors = [], type, items) =>
-  items && type
-    ? { valid: false, errors, type, items }
-    : { valid: false, errors };
+type _err = (errors?: string | Errors, type?: ErrType, items?: Items) => Result;
+export const err: _err = (errors = [], type, items) => {
+  const errorList = Array.isArray(errors) ? errors : [errors];
+  return items && type
+    ? { valid: false, errors: errorList, type, items }
+    : { valid: false, errors: errorList };
+};
 
 /**
  * Is the given result OK?

--- a/src/lib/result.js
+++ b/src/lib/result.js
@@ -2,47 +2,61 @@
 import { addIndex, concat, map, merge, mergeWith, reduce } from 'ramda';
 
 /**
- * Types
+ * Error messages are represented as strings
  */
 export type Errors = Array<string>;
 
+/**
+ * A Result can be OK, which is valid, or an Err, which is invalid. An Err
+ * an array of errors, an optional type, and optional nested error items
+ */
 type OK = {| valid: true |};
 
 type Items = {
   [string]: Result
 };
 
+type ErrType = 'array' | 'object';
+
 type Err = {|
   valid: false,
   errors: Errors,
-  type?: string,
+  type?: ErrType,
   items?: Items
 |};
 
 export type Result = OK | Err;
 
 /**
- * Constructors
+ * Constructs an OK result
  */
 type _ok = () => OK;
 export const ok: _ok = () => ({ valid: true });
 
-type _err = (errors?: Errors, type?: string, items?: Items) => Result;
+/**
+ * Constructs an Err result
+ */
+type _err = (errors?: Errors, type?: ErrType, items?: Items) => Result;
 export const err: _err = (errors = [], type, items) =>
   items && type
     ? { valid: false, errors, type, items }
     : { valid: false, errors };
 
 /**
- * Helpers
+ * Is the given result OK?
  */
 type IsOK = Result => boolean;
 export const isOK: IsOK = ({ valid }) => valid !== undefined && valid;
 
+/**
+ * Is the given result an Err?
+ */
 type IsErr = Result => boolean;
 export const isErr: IsErr = ({ valid }) => valid !== undefined && !valid;
 
-// Apply a function to every error in a Result
+/**
+ * Applies a function to every error in a Result
+ */
 type MapErrors = ((string, ?number) => string) => Result => Result;
 export const mapErrors: MapErrors = f => r => {
   if (r.valid) return r;
@@ -57,9 +71,13 @@ export const mapErrors: MapErrors = f => r => {
     : withMappedErrors;
 };
 
-// Combine two results
+/**
+ * Combines two results, which must be of the same type ('array' or 'object').
+ * Nested results will be recursively merged
+ */
 type MergeResults = (Result, Result) => Result;
 export const mergeResults: MergeResults = (r1, r2) => {
+  // If either result is valid we can safely return the other
   if (r1.valid) return r2;
   if (r2.valid) return r1;
 
@@ -67,7 +85,7 @@ export const mergeResults: MergeResults = (r1, r2) => {
   const r1Items = r1.items || {};
   const r2Items = r2.items || {};
 
-  // Otherwise merge errors
+  // Otherwise merge the errors
   return {
     valid: false,
     errors: concat(r1.errors, r2.errors),
@@ -76,5 +94,9 @@ export const mergeResults: MergeResults = (r1, r2) => {
   };
 };
 
+/**
+ * Combines an array of results, which must all be of the same type ('array' or
+ * 'object')
+ */
 type ConcatResults = (Array<Result>) => Result;
 export const concatResults: ConcatResults = reduce(mergeResults, ok());

--- a/src/lib/result.js
+++ b/src/lib/result.js
@@ -104,7 +104,7 @@ export const mergeResults: MergeResults = (r1, r2) => {
   const result = {
     valid: false,
     errors: concat(r1.errors, r2.errors),
-    type: r1.type,
+    type: r1.type || r2.type,
   };
 
   return r1.items || r2.items

--- a/src/lib/result.js
+++ b/src/lib/result.js
@@ -37,6 +37,11 @@ export const isOK: IsOK = ({ valid }) => valid !== undefined && valid;
 type IsErr = Result => boolean;
 export const isErr: IsErr = ({ valid }) => valid !== undefined && !valid;
 
+// Convert a (possibly empty) array of errors into a Result
+type ToResult = Errors => Result;
+export const toResult: ToResult = errs =>
+  errs.length === 0 ? ok() : err(errs);
+
 // Apply a function to every error in a Result
 type MapErrors = ((string, ?number) => string) => Result => Result;
 export const mapErrors: MapErrors = f => r => {
@@ -63,13 +68,14 @@ export const mergeResults: MergeResults = (r1, r2) => {
   if (r1.valid) return r2;
   if (r2.valid) return r1;
 
+  // @TODO this will cause an `items` key to exist where it didn't before
   const r1Items = r1.items || {};
   const r2Items = r2.items || {};
 
   // Otherwise merge errors
   return {
     valid: false,
-    errors: concat(r1.errors, r2.errors), // intersection?
+    errors: concat(r1.errors, r2.errors),
     type: r1.type,
     items: mergeWith(mergeResults, r1Items, r2Items)
   };

--- a/src/lib/schema.js
+++ b/src/lib/schema.js
@@ -26,16 +26,7 @@ import {
 } from './validators';
 
 import { all, allWhileOK } from './compose';
-import {
-  type Result,
-  isErr,
-  err,
-  isOK,
-  ok,
-  prefixErrors,
-  concatResults
-} from './result';
-import { isObject } from './typecheck';
+import { type Result, isErr, err, isOK, ok, concatResults } from './result';
 import { getErrors } from './printer';
 
 /**

--- a/src/lib/schema.js
+++ b/src/lib/schema.js
@@ -11,11 +11,12 @@ import {
   validateArrayItemsHaveType,
   validateArrayItemsPass,
   alwaysOK,
-  alwaysErr,
+  alwaysErr
 } from './validators';
 
 import { all, allWhileOK } from './compose';
-import { type Result, isErr, err, mapErrors, getErrors } from './result';
+import { type Result, isErr, err, mapErrors } from './result';
+import { getErrors } from './printer';
 import { isObject } from './typecheck';
 
 /**
@@ -24,7 +25,7 @@ import { isObject } from './typecheck';
 type SchemaRules = {
   required?: boolean,
   type?: string,
-  validator?: Validator,
+  validator?: Validator
 };
 
 type ArraySchema = SchemaRules;
@@ -68,7 +69,7 @@ const validateAsNestedSchemaRules: ValidateAsNestedSchemaRules = field => schema
  */
 type ProcessSchemaError = Result => Array<Validator>;
 const processSchemaError: ProcessSchemaError = schemaResult => [
-  alwaysErr(getErrors(mapErrors(err => `Schema error: ${err}`)(schemaResult))),
+  alwaysErr(getErrors(mapErrors(err => `Schema error: ${err}`)(schemaResult)))
 ];
 
 /**
@@ -78,7 +79,7 @@ type ValidateAsObjectSchema = ObjectSchema => Result;
 export const validateAsObjectSchema: ValidateAsObjectSchema = schema =>
   allWhileOK([
     validateIsObject,
-    ...Object.keys(schema).map(validateAsNestedSchemaRules),
+    ...Object.keys(schema).map(validateAsNestedSchemaRules)
   ])(schema);
 
 /**
@@ -121,7 +122,7 @@ export const fromObjectSchema: FromObjectSchema = (schema = {}) => {
     validateIsObject,
     all(requiredChecks),
     all(typeChecks),
-    all(validatorChecks),
+    all(validatorChecks)
   ];
 };
 

--- a/src/lib/schema.js
+++ b/src/lib/schema.js
@@ -7,8 +7,7 @@ import {
   map,
   mapObjIndexed as mapObj,
   prepend,
-  reduce,
-  unnest
+  reduce
 } from 'ramda';
 
 import {

--- a/src/lib/schema.js
+++ b/src/lib/schema.js
@@ -11,9 +11,9 @@ import {
   validateObjOnlyHasKeys,
   validateIsArray,
   validateArrayItemsHaveType,
-  validateArrayItemsPass,
+  validateArrayItems,
   alwaysOK,
-  alwaysErr
+  alwaysErr,
 } from './validators';
 
 import { all, allWhileOK } from './compose';
@@ -30,7 +30,7 @@ import { getErrors } from './printer';
 type SchemaRules = {
   required?: boolean,
   type?: string,
-  validator?: Validator
+  validator?: Validator,
 };
 
 /**
@@ -87,7 +87,7 @@ const processSchemaError: ProcessSchemaError = compose(
 type ValidateAsObjectSchema = ObjectSchema => Result;
 export const validateAsObjectSchema: ValidateAsObjectSchema = allWhileOK([
   validateIsObject,
-  validateObjFields(validateAsSchemaRules)
+  validateObjFields(validateAsSchemaRules),
 ]);
 
 /**
@@ -96,7 +96,7 @@ export const validateAsObjectSchema: ValidateAsObjectSchema = allWhileOK([
 type ValidateAsArraySchema = ArraySchema => Result;
 export const validateAsArraySchema: ValidateAsArraySchema = allWhileOK([
   validateIsObject,
-  validateAsSchemaRules
+  validateAsSchemaRules,
 ]);
 
 /**
@@ -135,7 +135,7 @@ export const fromObjectSchema: FromObjectSchema = (schema = {}) => {
     validateIsObject,
     all(requiredChecks),
     all(typeChecks),
-    all(validatorChecks)
+    all(validatorChecks),
   ];
 };
 
@@ -160,7 +160,7 @@ export const fromArraySchema: FromArraySchema = (schema = {}) => {
       if (k === 'type' && schema[k]) {
         return append(validateArrayItemsHaveType(schema[k]), acc);
       } else if (k === 'validator' && schema[k]) {
-        return append(validateArrayItemsPass(schema[k]), acc);
+        return append(validateArrayItems(schema[k]), acc);
       } else return acc;
     },
     [],

--- a/src/lib/typecheck.js
+++ b/src/lib/typecheck.js
@@ -6,9 +6,9 @@
  * Ref: http://stackoverflow.com/questions/3143070/javascript-regex-iso-datetime
  */
 type IsISOString = any => boolean;
-export const isISOString: IsISOString = str =>
-  typeof str === 'string' &&
-  str.match(
+export const isISOString: IsISOString = val =>
+  typeof val === 'string' &&
+  val.match(
     /^\d{4}(-\d\d(-\d\d(T\d\d:\d\d(:\d\d)?(\.\d+)?(([+-]\d\d:\d\d)|Z)?)?)?)?$/i
   ) !== null;
 
@@ -29,7 +29,7 @@ export const isObject: IsObject = val =>
  * Is the parameter an array?
  */
 type IsArray = any => boolean;
-export const isArray: IsArray = arr => Array.isArray(arr);
+export const isArray: IsArray = val => Array.isArray(val);
 
 /**
  * Is the parameter null?

--- a/src/lib/validators.js
+++ b/src/lib/validators.js
@@ -5,12 +5,9 @@ import { isType } from './typecheck';
 import {
   type Result,
   type Errors,
-  toResult,
   ok,
   err,
   isOK,
-  isErr,
-  prefixErrors,
   concatResults
 } from './result';
 

--- a/src/lib/validators.js
+++ b/src/lib/validators.js
@@ -7,7 +7,7 @@ import {
   keys,
   map,
   mapObjIndexed as mapObj,
-  values
+  values,
 } from 'ramda';
 
 import { isType } from './typecheck';
@@ -16,8 +16,9 @@ import {
   type Errors,
   ok,
   err,
+  nestedErr,
   isOK,
-  concatResults
+  concatResults,
 } from './result';
 
 /**
@@ -92,7 +93,7 @@ export const validateObjFields: ValidateObjFields = validator =>
     values,
     mapObj((v, k) => {
       const res = validator(v);
-      return isOK(res) ? ok() : err([], 'object', { [k]: res });
+      return isOK(res) ? ok() : nestedErr('object', { [k]: res });
     })
   );
 
@@ -143,7 +144,7 @@ export const validateArrayItems: ValidateArrayItems = validator =>
     concatResults,
     curry(addIndex(map))((d, i) => {
       const res = validator(d);
-      return isOK(res) ? res : err([], 'array', { [i]: res });
+      return isOK(res) ? res : nestedErr('array', { [i]: res });
     })
   );
 

--- a/src/lib/validators.js
+++ b/src/lib/validators.js
@@ -12,10 +12,10 @@ import {
 } from './result';
 
 /**
- * Types
+ * A Validator accepts some data, runs checks against it, and returns a result
+ * that is either OK or an Err
  */
 export type Data = any;
-
 export type Validator = Data => Result;
 
 // @TODO move these
@@ -26,19 +26,19 @@ const buildArrayRes = idx => res =>
   isOK(res) ? ok() : err([], 'array', { [idx]: res });
 
 /**
- * Always an error
+ * Always returns an Err with the given errors
  */
 type AlwaysErr = Errors => Validator;
 export const alwaysErr: AlwaysErr = errs => () => err(errs);
 
 /**
- * Always OK
+ * Always returns OK
  */
 type AlwaysOK = () => Validator;
 export const alwaysOK: AlwaysOK = () => () => ok();
 
 /**
- * Construct a validator from a boolean function
+ * Constructs a validator from a boolean function
  */
 type FromPredicate = ((Data) => boolean, (Data) => string) => Validator;
 export const fromPredicate: FromPredicate = (test, toErrMsg) => data =>

--- a/src/lib/validators.js
+++ b/src/lib/validators.js
@@ -156,9 +156,3 @@ export const validateArrayItemsHaveType: ValidateArrayItemsHaveType = compose(
   validateArrayItems,
   validateIsType
 );
-
-/**
- * Does each array item pass the given validator?
- */
-type ValidateArrayItemsPass = Validator => Validator;
-export const validateArrayItemsPass: ValidateArrayItemsPass = validateArrayItems;

--- a/src/lib/validators.js
+++ b/src/lib/validators.js
@@ -1,7 +1,7 @@
 // @flow
 
 import { isType } from './typecheck';
-import { ok, err, toResult, prefixErrors, flattenResults } from './result';
+import { ok, err, prefixErrors, concatResults } from './result';
 import type { Result, Errors } from './result';
 
 /**
@@ -108,13 +108,13 @@ export const validateIsArray: ValidateIsArray = validateIsType('array');
  */
 type ValidateArrayItemsHaveType = string => Validator;
 export const validateArrayItemsHaveType: ValidateArrayItemsHaveType = type => arr =>
-  prefixErrors(`Item `)(flattenResults(arr.map(validateIsType(type))));
+  prefixErrors(`Item `)(concatResults(arr.map(validateIsType(type))));
 
 /**
  * Does each array item pass the given validator?
  */
 type ValidateArrayItemsPass = Validator => Validator;
 export const validateArrayItemsPass: ValidateArrayItemsPass = v => arr =>
-  flattenResults(
+  concatResults(
     arr.map(v).map((res, i) => prefixErrors(`At item ${i}: `)(res))
   );

--- a/src/lib/validators.js
+++ b/src/lib/validators.js
@@ -42,7 +42,7 @@ export const alwaysOK: AlwaysOK = () => () => ok();
  */
 type FromPredicate = ((Data) => boolean, (Data) => string) => Validator;
 export const fromPredicate: FromPredicate = (test, toErrMsg) => data =>
-  test(data) ? ok() : err([toErrMsg(data)]);
+  test(data) ? ok() : err(toErrMsg(data));
 
 /**
  * Is the given object of the given type?
@@ -89,7 +89,7 @@ export const validateObjPropHasType: ValidateObjPropHasType = type => key => obj
   const val = obj[key];
   const res = isType(type)(val)
     ? ok()
-    : err([`${JSON.stringify(val)} failed to typecheck (expected ${type})`]);
+    : err(`${JSON.stringify(val)} failed to typecheck (expected ${type})`);
 
   return buildObjRes(key)(res);
 };
@@ -110,7 +110,7 @@ type ValidateObjOnlyHasKeys = (Array<string>) => Validator;
 export const validateObjOnlyHasKeys: ValidateObjOnlyHasKeys = requiredKeys =>
   compose(
     concatResults,
-    map(k => err([`Extra field "${k}"`])),
+    map(k => err(`Extra field "${k}"`)),
     filter(k => !requiredKeys.includes(k)),
     keys
   );

--- a/test/compose.spec.js
+++ b/test/compose.spec.js
@@ -150,8 +150,8 @@ describe('compose', () => {
     it('returns errors from all the validators if it fails', () => {
       const validate = some([validateIsObject, validateIsArray]);
       expect(getErrors(validate(123))).to.deep.equal([
-        '"123" failed to typecheck (expected object)',
-        '"123" failed to typecheck (expected array)'
+        '123 failed to typecheck (expected object)',
+        '123 failed to typecheck (expected array)'
       ]);
     });
 

--- a/test/compose.spec.js
+++ b/test/compose.spec.js
@@ -106,19 +106,19 @@ describe('compose', () => {
         validateObjPropHasType('string')('field1')
       ]);
 
-      expect(validate('not an object').errors).to.deep.equal([
+      expect(getErrors(validate('not an object'))).to.deep.equal([
         `"not an object" failed to typecheck (expected object)`
       ]);
 
-      expect(validate({}).errors).to.deep.equal([
+      expect(getErrors(validate({}))).to.deep.equal([
         `Missing required field "field1"`
       ]);
 
-      expect(validate({ field1: {} }).errors).to.deep.equal([
+      expect(getErrors(validate({ field1: {} }))).to.deep.equal([
         `Field \"field1\" failed to typecheck (expected string)`
       ]);
 
-      expect(validate({ field2: 'here' }).errors).to.deep.equal([
+      expect(getErrors(validate({ field2: 'here' }))).to.deep.equal([
         `Missing required field "field1"`
       ]);
     });
@@ -150,7 +150,7 @@ describe('compose', () => {
 
     it('returns errors from all the validators if it fails', () => {
       const validate = some([validateIsObject, validateIsArray]);
-      expect(validate(123).errors).to.deep.equal([
+      expect(getErrors(validate(123))).to.deep.equal([
         '"123" failed to typecheck (expected object)',
         '"123" failed to typecheck (expected array)'
       ]);

--- a/test/compose.spec.js
+++ b/test/compose.spec.js
@@ -8,8 +8,7 @@ import {
   validateIsObject,
   validateObjHasKey,
   validateObjPropHasType,
-  validateIsArray,
-  validateArrayItemsHaveType
+  validateIsArray
 } from '../src/lib/validators';
 
 describe('compose', () => {

--- a/test/compose.spec.js
+++ b/test/compose.spec.js
@@ -8,10 +8,77 @@ import {
   validateIsObject,
   validateObjHasKey,
   validateObjPropHasType,
-  validateIsArray
+  validateIsArray,
 } from '../src/lib/validators';
 
 describe('compose', () => {
+  describe('#allWhileOK()', () => {
+    it('should compose multiple validators into a single validator such that they all must succeed', () => {
+      const validate = allWhileOK([
+        validateIsObject,
+        validateObjHasKey('field1'),
+      ]);
+
+      expect(isErr(validate('not an object'))).to.be.true;
+      expect(isErr(validate({}))).to.be.true;
+      expect(isErr(validate({ field2: 'here' }))).to.be.true;
+
+      expect(isOK(validate({ field1: 'here' }))).to.be.true;
+    });
+
+    it('can compose multiple times', () => {
+      const v1 = allWhileOK([validateIsObject]);
+      const v2 = allWhileOK([v1, validateObjHasKey('field1')]);
+      const validate = allWhileOK([v2, validateObjHasKey('field2')]);
+
+      expect(isErr(validate('not an object'))).to.be.true;
+      expect(isErr(validate({}))).to.be.true;
+      expect(isErr(validate({ field2: 'here' }))).to.be.true;
+      expect(isErr(validate({ field1: 'here', field3: 'also here' }))).to.be
+        .true;
+
+      expect(isOK(validate({ field1: 'here', field2: 'also here' }))).to.be
+        .true;
+    });
+
+    it('runs the composed validators in order, stopping when a failure occurs, and returns the first error', () => {
+      const validate = allWhileOK([
+        validateIsObject,
+        validateObjHasKey('field1'),
+        validateObjPropHasType('string')('field1'),
+      ]);
+
+      expect(getErrors(validate('not an object'))).to.deep.equal([
+        `"not an object" failed to typecheck (expected object)`,
+      ]);
+
+      expect(getErrors(validate({}))).to.deep.equal([
+        `Missing required field "field1"`,
+      ]);
+
+      expect(getErrors(validate({ field1: {} }))).to.deep.equal([
+        `At field \"field1\": {} failed to typecheck (expected string)`,
+      ]);
+
+      expect(getErrors(validate({ field2: 'here' }))).to.deep.equal([
+        `Missing required field "field1"`,
+      ]);
+    });
+
+    it('can compose with a brand new validator', () => {
+      const arbitraryValidator = data =>
+        data.hasOwnProperty('arbitraryField')
+          ? ok()
+          : err(`Couldn't find arbitraryField`);
+
+      const validate = allWhileOK([validateIsObject, arbitraryValidator]);
+
+      expect(isErr(validate(''))).to.be.true;
+      expect(isErr(validate({}))).to.be.true;
+      expect(isOK(validate({ arbitraryField: 'boo' }))).to.be.true;
+    });
+  });
+
   describe('#all()', () => {
     it('should compose multiple validators into a single validator such that they all must succeed', () => {
       const validate = all([validateIsObject, validateObjHasKey('field1')]);
@@ -43,15 +110,15 @@ describe('compose', () => {
 
       expect(getErrors(validate('not an object'))).to.deep.equal([
         `"not an object" failed to typecheck (expected object)`,
-        `Missing required field \"field1\"`
+        `Missing required field \"field1\"`,
       ]);
 
       expect(getErrors(validate({}))).to.deep.equal([
-        `Missing required field "field1"`
+        `Missing required field "field1"`,
       ]);
 
       expect(getErrors(validate({ field2: 'here' }))).to.deep.equal([
-        `Missing required field "field1"`
+        `Missing required field "field1"`,
       ]);
     });
 
@@ -62,73 +129,6 @@ describe('compose', () => {
           : err("Couldn't find arbitraryField");
 
       const validate = all([validateIsObject, arbitraryValidator]);
-
-      expect(isErr(validate(''))).to.be.true;
-      expect(isErr(validate({}))).to.be.true;
-      expect(isOK(validate({ arbitraryField: 'boo' }))).to.be.true;
-    });
-  });
-
-  describe('#allWhileOK()', () => {
-    it('should compose multiple validators into a single validator such that they all must succeed', () => {
-      const validate = allWhileOK([
-        validateIsObject,
-        validateObjHasKey('field1')
-      ]);
-
-      expect(isErr(validate('not an object'))).to.be.true;
-      expect(isErr(validate({}))).to.be.true;
-      expect(isErr(validate({ field2: 'here' }))).to.be.true;
-
-      expect(isOK(validate({ field1: 'here' }))).to.be.true;
-    });
-
-    it('can compose multiple times', () => {
-      const v1 = allWhileOK([validateIsObject]);
-      const v2 = allWhileOK([v1, validateObjHasKey('field1')]);
-      const validate = allWhileOK([v2, validateObjHasKey('field2')]);
-
-      expect(isErr(validate('not an object'))).to.be.true;
-      expect(isErr(validate({}))).to.be.true;
-      expect(isErr(validate({ field2: 'here' }))).to.be.true;
-      expect(isErr(validate({ field1: 'here', field3: 'also here' }))).to.be
-        .true;
-
-      expect(isOK(validate({ field1: 'here', field2: 'also here' }))).to.be
-        .true;
-    });
-
-    it('runs the composed validators in order, stopping when a failure occurs, and returns the first error', () => {
-      const validate = allWhileOK([
-        validateIsObject,
-        validateObjHasKey('field1'),
-        validateObjPropHasType('string')('field1')
-      ]);
-
-      expect(getErrors(validate('not an object'))).to.deep.equal([
-        `"not an object" failed to typecheck (expected object)`
-      ]);
-
-      expect(getErrors(validate({}))).to.deep.equal([
-        `Missing required field "field1"`
-      ]);
-
-      expect(getErrors(validate({ field1: {} }))).to.deep.equal([
-        `At field \"field1\": {} failed to typecheck (expected string)`
-      ]);
-
-      expect(getErrors(validate({ field2: 'here' }))).to.deep.equal([
-        `Missing required field "field1"`
-      ]);
-    });
-
-    it('can compose with a brand new validator', () => {
-      const arbitraryValidator = data =>
-        data.hasOwnProperty('arbitraryField')
-          ? ok()
-          : err(`Couldn't find arbitraryField`);
-
-      const validate = allWhileOK([validateIsObject, arbitraryValidator]);
 
       expect(isErr(validate(''))).to.be.true;
       expect(isErr(validate({}))).to.be.true;
@@ -151,7 +151,7 @@ describe('compose', () => {
       const validate = some([validateIsObject, validateIsArray]);
       expect(getErrors(validate(123))).to.deep.equal([
         '123 failed to typecheck (expected object)',
-        '123 failed to typecheck (expected array)'
+        '123 failed to typecheck (expected array)',
       ]);
     });
 

--- a/test/compose.spec.js
+++ b/test/compose.spec.js
@@ -115,7 +115,7 @@ describe('compose', () => {
       ]);
 
       expect(getErrors(validate({ field1: {} }))).to.deep.equal([
-        `Field \"field1\" failed to typecheck (expected string)`
+        `At field \"field1\": {} failed to typecheck (expected string)`
       ]);
 
       expect(getErrors(validate({ field2: 'here' }))).to.deep.equal([

--- a/test/compose.spec.js
+++ b/test/compose.spec.js
@@ -1,14 +1,15 @@
 import { expect } from 'chai';
 
 import { all, allWhileOK, some } from '../src/lib/compose';
-import { isOK, isErr, ok, err, toResult } from '../src/lib/result';
+import { isOK, isErr, ok, err } from '../src/lib/result';
+import { getErrors } from '../src/lib/printer';
 
 import {
   validateIsObject,
   validateObjHasKey,
   validateObjPropHasType,
   validateIsArray,
-  validateArrayItemsHaveType,
+  validateArrayItemsHaveType
 } from '../src/lib/validators';
 
 describe('compose', () => {
@@ -41,17 +42,17 @@ describe('compose', () => {
     it('runs the composed validators in order', () => {
       const validate = all([validateIsObject, validateObjHasKey('field1')]);
 
-      expect(validate('not an object').errors).to.deep.equal([
+      expect(getErrors(validate('not an object'))).to.deep.equal([
         `"not an object" failed to typecheck (expected object)`,
-        `Missing required field \"field1\"`,
+        `Missing required field \"field1\"`
       ]);
 
-      expect(validate({}).errors).to.deep.equal([
-        `Missing required field "field1"`,
+      expect(getErrors(validate({}))).to.deep.equal([
+        `Missing required field "field1"`
       ]);
 
-      expect(validate({ field2: 'here' }).errors).to.deep.equal([
-        `Missing required field "field1"`,
+      expect(getErrors(validate({ field2: 'here' }))).to.deep.equal([
+        `Missing required field "field1"`
       ]);
     });
 
@@ -59,7 +60,7 @@ describe('compose', () => {
       const arbitraryValidator = data =>
         data.hasOwnProperty('arbitraryField')
           ? ok()
-          : err([`Couldn't find arbitraryField`]);
+          : err(["Couldn't find arbitraryField"]);
 
       const validate = all([validateIsObject, arbitraryValidator]);
 
@@ -73,7 +74,7 @@ describe('compose', () => {
     it('should compose multiple validators into a single validator such that they all must succeed', () => {
       const validate = allWhileOK([
         validateIsObject,
-        validateObjHasKey('field1'),
+        validateObjHasKey('field1')
       ]);
 
       expect(isErr(validate('not an object'))).to.be.true;
@@ -102,23 +103,23 @@ describe('compose', () => {
       const validate = allWhileOK([
         validateIsObject,
         validateObjHasKey('field1'),
-        validateObjPropHasType('string')('field1'),
+        validateObjPropHasType('string')('field1')
       ]);
 
       expect(validate('not an object').errors).to.deep.equal([
-        `"not an object" failed to typecheck (expected object)`,
+        `"not an object" failed to typecheck (expected object)`
       ]);
 
       expect(validate({}).errors).to.deep.equal([
-        `Missing required field "field1"`,
+        `Missing required field "field1"`
       ]);
 
       expect(validate({ field1: {} }).errors).to.deep.equal([
-        `Field \"field1\" failed to typecheck (expected string)`,
+        `Field \"field1\" failed to typecheck (expected string)`
       ]);
 
       expect(validate({ field2: 'here' }).errors).to.deep.equal([
-        `Missing required field "field1"`,
+        `Missing required field "field1"`
       ]);
     });
 
@@ -151,7 +152,7 @@ describe('compose', () => {
       const validate = some([validateIsObject, validateIsArray]);
       expect(validate(123).errors).to.deep.equal([
         '"123" failed to typecheck (expected object)',
-        '"123" failed to typecheck (expected array)',
+        '"123" failed to typecheck (expected array)'
       ]);
     });
 

--- a/test/compose.spec.js
+++ b/test/compose.spec.js
@@ -59,7 +59,7 @@ describe('compose', () => {
       const arbitraryValidator = data =>
         data.hasOwnProperty('arbitraryField')
           ? ok()
-          : err(["Couldn't find arbitraryField"]);
+          : err("Couldn't find arbitraryField");
 
       const validate = all([validateIsObject, arbitraryValidator]);
 
@@ -126,7 +126,7 @@ describe('compose', () => {
       const arbitraryValidator = data =>
         data.hasOwnProperty('arbitraryField')
           ? ok()
-          : err([`Couldn't find arbitraryField`]);
+          : err(`Couldn't find arbitraryField`);
 
       const validate = allWhileOK([validateIsObject, arbitraryValidator]);
 

--- a/test/printer.spec.js
+++ b/test/printer.spec.js
@@ -1,83 +1,8 @@
 import { expect } from 'chai';
 
-import {
-  ok,
-  err,
-  isOK,
-  isErr,
-  mergeResults,
-  concatResults,
-  mapErrors,
-  allWhileOK,
-  all,
-  valStrLen,
-  valStrStartsWith,
-  valStr,
-  printVerbose,
-  getErrors
-} from '../src/lib/printer';
+import { printVerbose, getErrors } from '../src/lib/printer';
 
-describe.only('printer', () => {
-  describe.only('#', () => {
-    it(`constructs valid and invalid results`, () => {
-      expect(isOK(ok())).to.be.true;
-      expect(isOK(err('x', 'err'))).to.be.false;
-
-      expect(isErr(ok())).to.be.false;
-      expect(isErr(err('x', 'err'))).to.be.true;
-    });
-
-    it('merges two results', () => {
-      const r1 = ok();
-      const r2 = err('x', 'err1');
-      const r3 = err('x', 'err2');
-
-      const m1 = mergeResults(r1, r2);
-      expect(getErrors(m1)).to.deep.equal(['err1']);
-
-      const m2 = mergeResults(r2, r3);
-      expect(getErrors(m2)).to.deep.equal(['err1', 'err2']);
-    });
-
-    it('concats results', () => {
-      const r1 = ok();
-      const r2 = err('x', 'err1');
-      const r3 = err('x', 'err2');
-
-      expect(getErrors(concatResults([r1, r2, r3]))).to.deep.equal([
-        'err1',
-        'err2'
-      ]);
-
-      expect(getErrors(concatResults([ok(), ok()]))).to.deep.equal([]);
-    });
-
-    it('composes allWhileOK', () => {
-      const v = allWhileOK([valStrLen, valStrStartsWith('a')]);
-
-      expect(getErrors(v('xyz'))).to.deep.equal(['Length < 5']);
-      expect(getErrors(v('xyz123'))).to.deep.equal(['Expected a (got x)']);
-      expect(isOK(v('abc123'))).to.be.true;
-    });
-
-    it('composes all', () => {
-      const v = all([valStrLen, valStrStartsWith('a')]);
-
-      expect(getErrors(v('xyz'))).to.deep.equal([
-        'Length < 5',
-        'Expected a (got x)'
-      ]);
-
-      expect(isOK(v('abc123'))).to.be.true;
-    });
-
-    it('maps errors', () => {
-      const mapper = mapErrors(e => `*** ${e}`);
-      expect(getErrors(mapper(ok()))).to.deep.equal([]);
-      expect(getErrors(mapper(err('x', ['err'])))).to.deep.equal(['*** err']);
-    });
-  });
-
+describe('printer', () => {
   describe('#printVerbose()', () => {
     it('should print an error', () => {
       const ast = {

--- a/test/printer.spec.js
+++ b/test/printer.spec.js
@@ -1,0 +1,130 @@
+import { expect } from 'chai';
+
+import { printVerbose } from '../src/lib/printer';
+
+describe.only('printer', () => {
+  describe('#printVerbose()', () => {
+    it('should print an error', () => {
+      const ast = {
+        type: 'string',
+        value: 'abc',
+        errors: ['error1']
+      };
+
+      expect(printVerbose(ast)).to.deep.equal(['error1']);
+    });
+
+    it('should print an array of errors', () => {
+      const ast = {
+        type: 'array',
+        value: ['a', 'b', 'c'],
+        errors: [],
+        items: {
+          0: {
+            type: 'string',
+            value: 'a',
+            errors: ['error1']
+          },
+          1: {
+            type: 'string',
+            value: 'b',
+            errors: []
+          },
+          2: {
+            type: 'string',
+            value: 'c',
+            errors: ['error2']
+          }
+        }
+      };
+
+      expect(printVerbose(ast)).to.deep.equal([
+        'At item 0: error1',
+        'At item 2: error2'
+      ]);
+    });
+
+    it('should print an object of errors', () => {
+      const ast = {
+        type: 'object',
+        value: { a: 1, b: 2, c: { d: 3 } },
+        errors: [],
+        items: {
+          a: {
+            type: 'number',
+            value: 1,
+            errors: ['error1']
+          },
+          b: {
+            type: 'number',
+            value: 2,
+            errors: []
+          },
+          c: {
+            type: 'object',
+            value: { d: 3 },
+            errors: [],
+            items: {
+              d: {
+                type: 'number',
+                value: 3,
+                errors: ['error2']
+              }
+            }
+          }
+        }
+      };
+
+      expect(printVerbose(ast)).to.deep.equal([
+        'At field a: error1',
+        'At field c: at field d: error2'
+      ]);
+    });
+
+    it('should print a complex object of errors', () => {
+      const ast = {
+        type: 'object',
+        value: { a: { b: ['c', { d: 'e' }] } },
+        errors: [],
+        items: {
+          a: {
+            type: 'object',
+            value: { b: ['c', { d: 'e' }] },
+            errors: [],
+            items: {
+              b: {
+                type: 'array',
+                value: ['c', { d: 'e' }],
+                errors: [],
+                items: {
+                  0: {
+                    type: 'string',
+                    value: 'c',
+                    errors: ['error1']
+                  },
+                  1: {
+                    type: 'object',
+                    value: { d: 'e' },
+                    errors: [],
+                    items: {
+                      d: {
+                        type: 'string',
+                        value: 'e',
+                        errors: ['error2']
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      };
+
+      expect(printVerbose(ast)).to.deep.equal([
+        'At field a: at field b: at item 0: error1',
+        'At field a: at field b: at item 1: at field d: error2'
+      ]);
+    });
+  });
+});

--- a/test/printer.spec.js
+++ b/test/printer.spec.js
@@ -76,8 +76,8 @@ describe('printer', () => {
       };
 
       expect(printVerbose(ast)).to.deep.equal([
-        'At field a: error1',
-        'At field c: at field d: error2'
+        'At field "a": error1',
+        'At field "c": at field "d": error2'
       ]);
     });
 
@@ -122,8 +122,8 @@ describe('printer', () => {
       };
 
       expect(printVerbose(ast)).to.deep.equal([
-        'At field a: at field b: at item 0: error1',
-        'At field a: at field b: at item 1: at field d: error2'
+        'At field "a": at field "b": at item 0: error1',
+        'At field "a": at field "b": at item 1: at field "d": error2'
       ]);
     });
   });

--- a/test/result.spec.js
+++ b/test/result.spec.js
@@ -4,9 +4,7 @@ import {
   err,
   isOK,
   isErr,
-  toResult,
   mapErrors,
-  prefixErrors,
   mergeResults,
   concatResults
 } from '../src/lib/result';
@@ -67,22 +65,6 @@ describe('result', () => {
       const res = err(['a', 'b', 'c']);
 
       expect(getErrors(map(res))).to.deep.equal(['1. a', '2. b', '3. c']);
-    });
-  });
-
-  describe('#prefixErrors()', () => {
-    it('should not change the type of the Result', () => {
-      const map = prefixErrors('something');
-
-      expect(isOK(map(ok())));
-      expect(isErr(map(err())));
-    });
-
-    it('should prefix each error in a Result', () => {
-      const map = prefixErrors('P: ');
-      const res = err(['a', 'b', 'c']);
-
-      expect(getErrors(map(res))).to.deep.equal(['P: a', 'P: b', 'P: c']);
     });
   });
 

--- a/test/result.spec.js
+++ b/test/result.spec.js
@@ -19,13 +19,19 @@ describe('result', () => {
   });
 
   describe('#err()', () => {
-    it('constructs an Err object', () => {
+    it('constructs an Err object from an array of errors', () => {
       expect(err()).to.deep.equal({ valid: false, errors: [] });
 
       expect(err(['err1', 'err2'])).to.deep.equal({
         valid: false,
         errors: ['err1', 'err2']
       });
+    });
+
+    it('constructs an Err object from a single error', () => {
+      expect(err()).to.deep.equal({ valid: false, errors: [] });
+
+      expect(err('err1')).to.deep.equal({ valid: false, errors: ['err1'] });
     });
   });
 
@@ -43,7 +49,7 @@ describe('result', () => {
   describe('#isErr()', () => {
     it('returns true only for an Err object', () => {
       expect(isErr(err())).to.be.true;
-      expect(isErr(err(['Error message']))).to.be.true;
+      expect(isErr(err('Error message'))).to.be.true;
 
       expect(isErr(ok())).to.be.false;
       expect(isErr({})).to.be.false;

--- a/test/result.spec.js
+++ b/test/result.spec.js
@@ -100,13 +100,31 @@ describe('result', () => {
     });
 
     it('should merge two Errs into an Err', () => {
-      const res = mergeResults(err(['a']), err(['b']));
+      const res = mergeResults(err('a'), err('b'));
       expect(isErr(res)).to.be.true;
       expect(getErrors(res)).to.deep.equal(['a', 'b']);
     });
 
+    it('should merge nested Errs into an Err', () => {
+      const res = mergeResults(
+        nestedErr('object', { a: err('a') }),
+        nestedErr('object', { b: err('b') })
+      );
+      expect(isErr(res)).to.be.true;
+      expect(getErrors(res)).to.deep.equal([
+        'At field "a": a',
+        'At field "b": b',
+      ]);
+    });
+
+    it('should merge a non-nested Err with a nested Err into an Err', () => {
+      const res = mergeResults(nestedErr('object', { b: err('b') }), err('a'));
+      expect(isErr(res)).to.be.true;
+      expect(getErrors(res)).to.deep.equal(['a', 'At field "b": b']);
+    });
+
     it('should merge an OK and an Err into an Err', () => {
-      const res = mergeResults(err(['a']), ok());
+      const res = mergeResults(err('a'), ok());
       expect(isErr(res)).to.be.true;
       expect(getErrors(res)).to.deep.equal(['a']);
     });

--- a/test/schema.spec.js
+++ b/test/schema.spec.js
@@ -6,47 +6,48 @@ import {
   fromObjectSchemaStrict,
   fromArraySchema,
   objectValidator,
-  arrayValidator,
+  arrayValidator
 } from '../src/lib/schema';
 
 import {
   validateIsObject,
   validateObjHasKey,
-  validateArrayItemsHaveType,
+  validateArrayItemsHaveType
 } from '../src/lib/validators';
 
 import { isOK, isErr, err, ok, toResult } from '../src/lib/result';
 import { all, allWhileOK } from '../src/lib/compose';
+import { getErrors } from '../src/lib/printer';
 
 describe('schema', () => {
   describe('#validateAsObjectSchema()', () => {
     it('should return a Result which validates the supplied object schema', () => {
       const validSchema1 = validateAsObjectSchema({
         field1: {
-          required: true,
+          required: true
         },
         field2: {
-          type: 'string',
-        },
+          type: 'string'
+        }
       });
 
       expect(isOK(validSchema1)).to.be.true;
 
       const validSchema2 = validateAsObjectSchema({
         field1: {
-          otherProp: true,
-        },
+          otherProp: true
+        }
       });
 
       expect(isOK(validSchema2)).to.be.true;
 
       const invalidSchema1 = validateAsObjectSchema({
         field1: {
-          required: 'not-a-boolean',
+          required: 'not-a-boolean'
         },
         field2: {
-          type: 1234,
-        },
+          type: 1234
+        }
       });
 
       expect(isErr(invalidSchema1)).to.be.true;
@@ -56,17 +57,17 @@ describe('schema', () => {
   describe('#validateAsArraySchema()', () => {
     it('should return a Result which validates the supplied array schema', () => {
       const validSchema = validateAsArraySchema({
-        type: 'string',
+        type: 'string'
       });
       expect(isOK(validSchema)).to.be.true;
 
       const invalidSchema = validateAsArraySchema({
-        type: 1234,
+        type: 1234
       });
       expect(isErr(invalidSchema)).to.be.true;
 
       const invalidSchema2 = validateAsArraySchema({
-        validator: 'not-a-function',
+        validator: 'not-a-function'
       });
       expect(isErr(invalidSchema2)).to.be.true;
     });
@@ -90,8 +91,8 @@ describe('schema', () => {
       expect(isErr(validate('string'))).to.be.true;
       expect(isErr(validate({}))).to.be.true;
 
-      expect(validate([]).errors).to.deep.equal([
-        'Schema error: Schemas must be objects',
+      expect(getErrors(validate([]))).to.deep.equal([
+        'Schema error: Schemas must be objects'
       ]);
     });
 
@@ -99,9 +100,9 @@ describe('schema', () => {
       const vs = fromObjectSchema({
         field1: 'test-1234',
         field2: {
-          required: true,
+          required: true
         },
-        field3: 'something',
+        field3: 'something'
       });
 
       expect(vs.length).to.equal(1);
@@ -111,16 +112,16 @@ describe('schema', () => {
       expect(isErr(validate({}))).to.be.true;
       expect(isErr(validate({ field2: 1234 }))).to.be.true;
 
-      expect(validate({ field2: 1234 }).errors).to.deep.equal([
-        'Schema error: "test-1234" failed to typecheck (expected object)',
+      expect(getErrors(validate({ field2: 1234 }))).to.deep.equal([
+        'Schema error: "test-1234" failed to typecheck (expected object)'
       ]);
     });
 
     it('should handle cases where a schema field passes an invalid required property', () => {
       const vs = fromObjectSchema({
         field1: {
-          required: 'yes',
-        },
+          required: 'yes'
+        }
       });
 
       expect(vs.length).to.equal(1);
@@ -128,16 +129,16 @@ describe('schema', () => {
       const validate = allWhileOK(vs);
       expect(isErr(validate('string'))).to.be.true;
       expect(isErr(validate({}))).to.be.true;
-      expect(validate({}).errors).to.deep.equal([
-        `Schema error: Field "required" failed to typecheck (expected boolean)`,
+      expect(getErrors(validate({}))).to.deep.equal([
+        `Schema error: Field "required" failed to typecheck (expected boolean)`
       ]);
     });
 
     it('should handle cases where a schema field passes an invalid type property', () => {
       const vs = fromObjectSchema({
         field1: {
-          type: 123,
-        },
+          type: 123
+        }
       });
 
       expect(vs.length).to.equal(1);
@@ -145,16 +146,16 @@ describe('schema', () => {
       const validate = allWhileOK(vs);
       expect(isErr(validate('string'))).to.be.true;
       expect(isErr(validate({}))).to.be.true;
-      expect(validate({}).errors).to.deep.equal([
-        `Schema error: Field "type" failed to typecheck (expected string)`,
+      expect(getErrors(validate({}))).to.deep.equal([
+        `Schema error: Field "type" failed to typecheck (expected string)`
       ]);
     });
 
     it('should handle cases where a schema field passes an invalid validator property', () => {
       const vs = fromObjectSchema({
         field1: {
-          validator: { not: 'a', function: true },
-        },
+          validator: { not: 'a', function: true }
+        }
       });
 
       expect(vs.length).to.equal(1);
@@ -162,16 +163,16 @@ describe('schema', () => {
       const validate = allWhileOK(vs);
       expect(isErr(validate('string'))).to.be.true;
       expect(isErr(validate({}))).to.be.true;
-      expect(validate({}).errors).to.deep.equal([
-        `Schema error: Field "validator" failed to typecheck (expected function)`,
+      expect(getErrors(validate({}))).to.deep.equal([
+        `Schema error: Field "validator" failed to typecheck (expected function)`
       ]);
     });
 
     it('should check the existence of required fields', () => {
       const vs1 = fromObjectSchema({
         field1: {
-          required: true,
-        },
+          required: true
+        }
       });
       expect(vs1.length).to.equal(4);
 
@@ -184,8 +185,8 @@ describe('schema', () => {
     it('should check the types of fields', () => {
       const vs = fromObjectSchema({
         field1: {
-          type: 'string',
-        },
+          type: 'string'
+        }
       });
       expect(vs.length).to.equal(4);
 
@@ -199,14 +200,14 @@ describe('schema', () => {
       const vs = fromObjectSchema({
         field1: {
           required: true,
-          type: 'number',
+          type: 'number'
         },
         field2: {
-          required: true,
+          required: true
         },
         field3: {
-          type: 'array',
-        },
+          type: 'array'
+        }
       });
       expect(vs.length).to.equal(4);
 
@@ -225,8 +226,8 @@ describe('schema', () => {
     it('should support nested validators', () => {
       const vs = fromObjectSchema({
         field1: {
-          validator: validateIsObject,
-        },
+          validator: validateIsObject
+        }
       });
       expect(vs.length).to.equal(4);
 
@@ -239,31 +240,33 @@ describe('schema', () => {
     it('should return prefixed error messages from nested validators', () => {
       const vs1 = fromObjectSchema({
         field1: {
-          validator: validateIsObject,
-        },
+          validator: validateIsObject
+        }
       });
       const validate1 = all(vs1);
-      expect(validate1({ field1: 12345 }).errors).to.deep.equal([
-        `At field "field1": "12345" failed to typecheck (expected object)`,
+      expect(getErrors(validate1({ field1: 12345 }))).to.deep.equal([
+        `At field "field1": "12345" failed to typecheck (expected object)`
       ]);
 
       // One level deeper
       const vs2 = fromObjectSchema({
         field2: {
-          validator: all(vs1),
-        },
+          validator: all(vs1)
+        }
       });
       const validate2 = all(vs2);
-      expect(validate2({ field2: { field1: 12345 } }).errors).to.deep.equal([
-        `At field "field2": At field "field1": "12345" failed to typecheck (expected object)`,
-      ]);
+      expect(getErrors(validate2({ field2: { field1: 12345 } }))).to.deep.equal(
+        [
+          `At field "field2": At field "field1": "12345" failed to typecheck (expected object)`
+        ]
+      );
     });
 
     it('should ignore other schema fields', () => {
       const vs = fromObjectSchema({
         field1: {
-          otherRule: true,
-        },
+          otherRule: true
+        }
       });
       expect(vs.length).to.equal(4);
     });
@@ -271,8 +274,8 @@ describe('schema', () => {
     it('should allow non-specified fields to exist', () => {
       const vs = fromObjectSchema({
         field1: {
-          otherRule: true,
-        },
+          otherRule: true
+        }
       });
 
       const validate = all(vs);
@@ -305,7 +308,7 @@ describe('schema', () => {
 
       const vs2 = fromObjectSchemaStrict({
         field1: {},
-        field2: {},
+        field2: {}
       });
       const validate2 = all(vs2);
 
@@ -332,42 +335,42 @@ describe('schema', () => {
       expect(isErr(validate('string'))).to.be.true;
       expect(isErr(validate([]))).to.be.true;
 
-      expect(validate([]).errors).to.deep.equal([
-        'Schema error: Schemas must be objects',
+      expect(getErrors(validate([]))).to.deep.equal([
+        'Schema error: Schemas must be objects'
       ]);
     });
 
     it('should handle cases where a schema field passes an invalid type property', () => {
       const vs = fromArraySchema({
-        type: 12345,
+        type: 12345
       });
       expect(vs.length).to.equal(1);
 
       const validate = allWhileOK(vs);
       expect(isErr(validate([]))).to.be.true;
 
-      expect(validate([]).errors).to.deep.equal([
-        'Schema error: Field "type" failed to typecheck (expected string)',
+      expect(getErrors(validate([]))).to.deep.equal([
+        'Schema error: Field "type" failed to typecheck (expected string)'
       ]);
     });
 
     it('should handle cases where a schema field passes an invalid validator property', () => {
       const vs = fromArraySchema({
-        validator: { not: 'a', function: true },
+        validator: { not: 'a', function: true }
       });
       expect(vs.length).to.equal(1);
 
       const validate = allWhileOK(vs);
       expect(isErr(validate([]))).to.be.true;
 
-      expect(validate([]).errors).to.deep.equal([
-        'Schema error: Field "validator" failed to typecheck (expected function)',
+      expect(getErrors(validate([]))).to.deep.equal([
+        'Schema error: Field "validator" failed to typecheck (expected function)'
       ]);
     });
 
     it('should add validators to check the types of fields', () => {
       const vs = fromArraySchema({
-        type: 'string',
+        type: 'string'
       });
       expect(vs.length).to.equal(2);
 
@@ -380,7 +383,7 @@ describe('schema', () => {
 
     it('should support item validators', () => {
       const vs = fromArraySchema({
-        validator: validateIsObject,
+        validator: validateIsObject
       });
       expect(vs.length).to.equal(2);
 
@@ -392,26 +395,26 @@ describe('schema', () => {
 
     it('should return prefixed error messages from item validators', () => {
       const vs1 = fromArraySchema({
-        validator: validateIsObject,
+        validator: validateIsObject
       });
       const validate1 = all(vs1);
-      expect(validate1([{}, 1, {}]).errors).to.deep.equal([
-        `At item 1: "1" failed to typecheck (expected object)`,
+      expect(getErrors(validate1([{}, 1, {}]))).to.deep.equal([
+        `At item 1: "1" failed to typecheck (expected object)`
       ]);
 
       // One level deeper
       const vs2 = fromArraySchema({
-        validator: all(vs1),
+        validator: all(vs1)
       });
       const validate2 = all(vs2);
-      expect(validate2([[{}], [1]]).errors).to.deep.equal([
-        `At item 1: At item 0: "1" failed to typecheck (expected object)`,
+      expect(getErrors(validate2([[{}], [1]]))).to.deep.equal([
+        `At item 1: At item 0: "1" failed to typecheck (expected object)`
       ]);
     });
 
     it('should ignore other schema fields', () => {
       const vs = fromArraySchema({
-        required: true,
+        required: true
       });
       const validate = all(vs);
       expect(vs.length).to.equal(1);
@@ -423,16 +426,16 @@ describe('schema', () => {
       const schema = {
         field1: {
           required: true,
-          type: 'string',
+          type: 'string'
         },
         field2: {
           type: 'number',
-          validator: x => (x < 10 ? ok() : err([`${x} was >= 10`])),
+          validator: x => (x < 10 ? ok() : err([`${x} was >= 10`]))
         },
         field3: {
           type: 'array',
-          validator: validateArrayItemsHaveType('object'),
-        },
+          validator: validateArrayItemsHaveType('object')
+        }
       };
 
       const validate = objectValidator(schema);
@@ -453,11 +456,11 @@ describe('schema', () => {
         .to.be.true;
 
       expect(
-        validate({ field1: 123, field2: 'hello', field3: 1234 }).errors
+        getErrors(validate({ field1: 123, field2: 'hello', field3: 1234 }))
       ).to.deep.equal([
         'Field "field1" failed to typecheck (expected string)',
         'Field "field2" failed to typecheck (expected number)',
-        'Field "field3" failed to typecheck (expected array)',
+        'Field "field3" failed to typecheck (expected array)'
       ]);
     });
 
@@ -465,16 +468,16 @@ describe('schema', () => {
       const schema = {
         field1: {
           required: true,
-          type: 'string',
+          type: 'string'
         },
         field2: {
           type: 'number',
-          validator: x => (x < 10 ? ok() : err([`${x} was >= 10`])),
+          validator: x => (x < 10 ? ok() : err([`${x} was >= 10`]))
         },
         field3: {
           type: 'array',
-          validator: validateArrayItemsHaveType('object'),
-        },
+          validator: validateArrayItemsHaveType('object')
+        }
       };
 
       const arbitraryValidator = data =>
@@ -484,7 +487,7 @@ describe('schema', () => {
 
       const validate = allWhileOK([
         objectValidator(schema),
-        arbitraryValidator,
+        arbitraryValidator
       ]);
 
       expect(isErr(validate(''))).to.be.true;
@@ -502,7 +505,7 @@ describe('schema', () => {
 
       const schema = {
         type: 'object',
-        validator: all([hasFewerThan3Keys, validateObjHasKey('field1')]),
+        validator: all([hasFewerThan3Keys, validateObjHasKey('field1')])
       };
 
       const validate = arrayValidator(schema);
@@ -520,7 +523,7 @@ describe('schema', () => {
 
     it('can compose with a brand new validator', () => {
       const schema = {
-        type: 'string',
+        type: 'string'
       };
 
       const arbitraryValidator = data =>
@@ -542,7 +545,7 @@ describe('schema', () => {
         isErr(validate(['string-longer-than-ten-characters', 'too-short']))
       ).to.be.true;
       expect(
-        validate(['string-longer-than-ten-characters', 'too-short']).errors
+        getErrors(validate(['string-longer-than-ten-characters', 'too-short']))
       ).to.deep.equal(['Item "too-short" not longer than 10 characters']);
     });
   });

--- a/test/schema.spec.js
+++ b/test/schema.spec.js
@@ -52,7 +52,8 @@ describe('schema', () => {
 
       expect(isErr(invalidSchema1)).to.be.true;
       expect(getErrors(invalidSchema1)).to.deep.equal([
-        `At field "required": "not-a-boolean" failed to typecheck (expected boolean)`
+        `At field "field1": at field "required": "not-a-boolean" failed to typecheck (expected boolean)`,
+        `At field "field2": at field "type": 1234 failed to typecheck (expected string)`
       ]);
     });
   });
@@ -82,7 +83,7 @@ describe('schema', () => {
     });
   });
 
-  describe.only('#fromObjectSchema()', () => {
+  describe('#fromObjectSchema()', () => {
     it('should handle cases where no schema is passed', () => {
       const vs = fromObjectSchema();
       expect(vs.length).to.equal(4);
@@ -103,7 +104,8 @@ describe('schema', () => {
       expect(vs.length).to.equal(1);
 
       const validate = all(vs);
-      const errMsg = 'Schema error: Schemas must be objects';
+      const errMsg =
+        'Schema error: "string" failed to typecheck (expected object)';
 
       expect(getErrors(validate('string'))).to.deep.equal([errMsg]);
       expect(getErrors(validate({}))).to.deep.equal([errMsg]);
@@ -115,8 +117,7 @@ describe('schema', () => {
         field1: 'test-1234',
         field2: {
           required: true
-        },
-        field3: 'something'
+        }
       });
 
       expect(vs.length).to.equal(1);
@@ -177,7 +178,7 @@ describe('schema', () => {
       expect(isErr(validate('string'))).to.be.true;
       expect(isErr(validate({}))).to.be.true;
       expect(getErrors(validate({}))).to.deep.equal([
-        `Schema error: At field "field1": at field "validator": "{ not: 'a', function: true }" failed to typecheck (expected function)`
+        `Schema error: At field "field1": at field "validator": {"not":"a","function":true} failed to typecheck (expected function)`
       ]);
     });
 
@@ -319,16 +320,27 @@ describe('schema', () => {
       expect(vs.length).to.equal(5);
 
       const validate = all(vs);
-      expect(isErr(validate('string'))).to.be.true;
+
+      const result = validate('string');
+      expect(isErr(result)).to.be.true;
+      expect(getErrors(result)).to.deep.equal([
+        `"string" failed to typecheck (expected object)`
+      ]);
+
       expect(isOK(validate({}))).to.be.true;
     });
 
     it('should handle cases where the schema is not an object', () => {
       const vs = fromObjectSchemaStrict('string');
-      expect(vs.length).to.equal(1);
+      expect(vs.length).to.equal(2);
 
       const validate = all(vs);
-      expect(isErr(validate('string'))).to.be.true;
+      const result = validate('string');
+      expect(isErr(result)).to.be.true;
+      expect(getErrors(result)).to.deep.equal([
+        `Schema error: "string" failed to typecheck (expected object)`
+      ]);
+
       expect(isErr(validate({}))).to.be.true;
     });
 
@@ -342,8 +354,9 @@ describe('schema', () => {
       });
       const validate2 = all(vs2);
 
-      expect(isErr(validate2({ field1: 'xxx', field2: 123, field3: 'yyy' }))).to
-        .be.true;
+      const result = validate2({ field1: 'xxx', field2: 123, field3: 'yyy' });
+      expect(isErr(result)).to.be.true;
+      expect(getErrors(result)).to.deep.equal([`Extra field "field3"`]);
     });
   });
 
@@ -353,7 +366,13 @@ describe('schema', () => {
       expect(vs.length).to.equal(1);
 
       const validate = all(vs);
-      expect(isErr(validate('string'))).to.be.true;
+
+      const result = validate('string');
+      expect(isErr(result)).to.be.true;
+      expect(getErrors(result)).to.deep.equal([
+        `"string" failed to typecheck (expected array)`
+      ]);
+
       expect(isOK(validate([]))).to.be.true;
     });
 
@@ -362,11 +381,11 @@ describe('schema', () => {
       expect(vs.length).to.equal(1);
 
       const validate = all(vs);
-      expect(isErr(validate('string'))).to.be.true;
-      expect(isErr(validate([]))).to.be.true;
 
-      expect(getErrors(validate([]))).to.deep.equal([
-        'Schema error: Schemas must be objects'
+      const result = validate('string');
+      expect(isErr(result)).to.be.true;
+      expect(getErrors(result)).to.deep.equal([
+        `Schema error: "string" failed to typecheck (expected object)`
       ]);
     });
 
@@ -377,10 +396,11 @@ describe('schema', () => {
       expect(vs.length).to.equal(1);
 
       const validate = allWhileOK(vs);
-      expect(isErr(validate([]))).to.be.true;
 
-      expect(getErrors(validate([]))).to.deep.equal([
-        'Schema error: Field "type" failed to typecheck (expected string)'
+      const result = validate([]);
+      expect(isErr(result)).to.be.true;
+      expect(getErrors(result)).to.deep.equal([
+        'Schema error: At field "type": 12345 failed to typecheck (expected string)'
       ]);
     });
 
@@ -394,7 +414,7 @@ describe('schema', () => {
       expect(isErr(validate([]))).to.be.true;
 
       expect(getErrors(validate([]))).to.deep.equal([
-        'Schema error: Field "validator" failed to typecheck (expected function)'
+        'Schema error: At field "validator": {"not":"a","function":true} failed to typecheck (expected function)'
       ]);
     });
 

--- a/test/schema.spec.js
+++ b/test/schema.spec.js
@@ -277,7 +277,7 @@ describe('schema', () => {
       });
       const validate1 = all(vs1);
       expect(getErrors(validate1({ field1: 12345 }))).to.deep.equal([
-        `At field "field1": "12345" failed to typecheck (expected object)`
+        `At field "field1": 12345 failed to typecheck (expected object)`
       ]);
 
       // One level deeper
@@ -289,7 +289,7 @@ describe('schema', () => {
       const validate2 = all(vs2);
       expect(getErrors(validate2({ field2: { field1: 12345 } }))).to.deep.equal(
         [
-          `At field "field2": at field "field1": "12345" failed to typecheck (expected object)`
+          `At field "field2": at field "field1": 12345 failed to typecheck (expected object)`
         ]
       );
     });
@@ -450,7 +450,7 @@ describe('schema', () => {
       });
       const validate1 = all(vs1);
       expect(getErrors(validate1([{}, 1, {}]))).to.deep.equal([
-        `At item 1: "1" failed to typecheck (expected object)`
+        `At item 1: 1 failed to typecheck (expected object)`
       ]);
 
       // One level deeper
@@ -459,7 +459,7 @@ describe('schema', () => {
       });
       const validate2 = all(vs2);
       expect(getErrors(validate2([[{}], [1]]))).to.deep.equal([
-        `At item 1: at item 0: "1" failed to typecheck (expected object)`
+        `At item 1: at item 0: 1 failed to typecheck (expected object)`
       ]);
     });
 

--- a/test/schema.spec.js
+++ b/test/schema.spec.js
@@ -51,6 +51,9 @@ describe('schema', () => {
       });
 
       expect(isErr(invalidSchema1)).to.be.true;
+      expect(getErrors(invalidSchema1)).to.deep.equal([
+        `At field "required": "not-a-boolean" failed to typecheck (expected boolean)`
+      ]);
     });
   });
 
@@ -65,21 +68,33 @@ describe('schema', () => {
         type: 1234
       });
       expect(isErr(invalidSchema)).to.be.true;
+      expect(getErrors(invalidSchema)).to.deep.equal([
+        `At field "type": 1234 failed to typecheck (expected string)`
+      ]);
 
       const invalidSchema2 = validateAsArraySchema({
         validator: 'not-a-function'
       });
       expect(isErr(invalidSchema2)).to.be.true;
+      expect(getErrors(invalidSchema2)).to.deep.equal([
+        `At field "validator": "not-a-function" failed to typecheck (expected function)`
+      ]);
     });
   });
 
-  describe('#fromObjectSchema()', () => {
+  describe.only('#fromObjectSchema()', () => {
     it('should handle cases where no schema is passed', () => {
       const vs = fromObjectSchema();
       expect(vs.length).to.equal(4);
 
       const validate = all(vs);
-      expect(isErr(validate('string'))).to.be.true;
+
+      const stringResult = validate('string');
+      expect(isErr(stringResult)).to.be.true;
+      expect(getErrors(stringResult)).to.deep.equal([
+        `"string" failed to typecheck (expected object)`
+      ]);
+
       expect(isOK(validate({}))).to.be.true;
     });
 
@@ -88,12 +103,11 @@ describe('schema', () => {
       expect(vs.length).to.equal(1);
 
       const validate = all(vs);
-      expect(isErr(validate('string'))).to.be.true;
-      expect(isErr(validate({}))).to.be.true;
+      const errMsg = 'Schema error: Schemas must be objects';
 
-      expect(getErrors(validate([]))).to.deep.equal([
-        'Schema error: Schemas must be objects'
-      ]);
+      expect(getErrors(validate('string'))).to.deep.equal([errMsg]);
+      expect(getErrors(validate({}))).to.deep.equal([errMsg]);
+      expect(getErrors(validate([]))).to.deep.equal([errMsg]);
     });
 
     it('should handle cases where a schema key is not an object', () => {
@@ -108,13 +122,12 @@ describe('schema', () => {
       expect(vs.length).to.equal(1);
 
       const validate = allWhileOK(vs);
-      expect(isErr(validate('string'))).to.be.true;
-      expect(isErr(validate({}))).to.be.true;
-      expect(isErr(validate({ field2: 1234 }))).to.be.true;
+      const errMsg = `Schema error: At field "field1": "test-1234" failed to typecheck (expected object)`;
 
-      expect(getErrors(validate({ field2: 1234 }))).to.deep.equal([
-        'Schema error: "test-1234" failed to typecheck (expected object)'
-      ]);
+      expect(getErrors(validate('string'))).to.deep.equal([errMsg]);
+      expect(getErrors(validate({}))).to.deep.equal([errMsg]);
+      expect(getErrors(validate({ field2: 1234 }))).to.deep.equal([errMsg]);
+      expect(getErrors(validate({ field2: 1234 }))).to.deep.equal([errMsg]);
     });
 
     it('should handle cases where a schema field passes an invalid required property', () => {
@@ -130,7 +143,7 @@ describe('schema', () => {
       expect(isErr(validate('string'))).to.be.true;
       expect(isErr(validate({}))).to.be.true;
       expect(getErrors(validate({}))).to.deep.equal([
-        `Schema error: Field "required" failed to typecheck (expected boolean)`
+        `Schema error: At field "field1": at field "required": "yes" failed to typecheck (expected boolean)`
       ]);
     });
 
@@ -147,7 +160,7 @@ describe('schema', () => {
       expect(isErr(validate('string'))).to.be.true;
       expect(isErr(validate({}))).to.be.true;
       expect(getErrors(validate({}))).to.deep.equal([
-        `Schema error: Field "type" failed to typecheck (expected string)`
+        `Schema error: At field "field1": at field "type": 123 failed to typecheck (expected string)`
       ]);
     });
 
@@ -164,22 +177,27 @@ describe('schema', () => {
       expect(isErr(validate('string'))).to.be.true;
       expect(isErr(validate({}))).to.be.true;
       expect(getErrors(validate({}))).to.deep.equal([
-        `Schema error: Field "validator" failed to typecheck (expected function)`
+        `Schema error: At field "field1": at field "validator": "{ not: 'a', function: true }" failed to typecheck (expected function)`
       ]);
     });
 
     it('should check the existence of required fields', () => {
-      const vs1 = fromObjectSchema({
+      const vs = fromObjectSchema({
         field1: {
           required: true
         }
       });
-      expect(vs1.length).to.equal(4);
+      expect(vs.length).to.equal(4);
 
-      const validate1 = all(vs1);
-      expect(isErr(validate1({}))).to.be.true;
-      expect(isErr(validate1({ field2: 'here' }))).to.be.true;
-      expect(isOK(validate1({ field1: 'here' }))).to.be.true;
+      const validate = all(vs);
+
+      const invalidResult = validate({ field2: 'here' });
+      expect(isErr(invalidResult)).to.be.true;
+      expect(getErrors(invalidResult)).to.deep.equal([
+        'Missing required field "field1"'
+      ]);
+
+      expect(isOK(validate({ field1: 'here' }))).to.be.true;
     });
 
     it('should check the types of fields', () => {
@@ -191,7 +209,13 @@ describe('schema', () => {
       expect(vs.length).to.equal(4);
 
       const validate = all(vs);
-      expect(isErr(validate({ field1: 123 }))).to.be.true;
+
+      const invalidResult = validate({ field1: 123 });
+      expect(isErr(invalidResult)).to.be.true;
+      expect(getErrors(invalidResult)).to.deep.equal([
+        `At field "field1": 123 failed to typecheck (expected string)`
+      ]);
+
       expect(isOK(validate({}))).to.be.true;
       expect(isOK(validate({ field1: 'here' }))).to.be.true;
     });
@@ -232,7 +256,13 @@ describe('schema', () => {
       expect(vs.length).to.equal(4);
 
       const validate = all(vs);
-      expect(isErr(validate({ field1: 'not an object' }))).to.be.true;
+
+      const result = validate({ field1: 'not an object' });
+      expect(isErr(result)).to.be.true;
+      expect(getErrors(result)).to.deep.equal([
+        `At field "field1": "not an object" failed to typecheck (expected object)`
+      ]);
+
       expect(isOK(validate({}))).to.be.true;
       expect(isOK(validate({ field1: {} }))).to.be.true;
     });
@@ -257,7 +287,7 @@ describe('schema', () => {
       const validate2 = all(vs2);
       expect(getErrors(validate2({ field2: { field1: 12345 } }))).to.deep.equal(
         [
-          `At field "field2": At field "field1": "12345" failed to typecheck (expected object)`
+          `At field "field2": at field "field1": "12345" failed to typecheck (expected object)`
         ]
       );
     });
@@ -408,7 +438,7 @@ describe('schema', () => {
       });
       const validate2 = all(vs2);
       expect(getErrors(validate2([[{}], [1]]))).to.deep.equal([
-        `At item 1: At item 0: "1" failed to typecheck (expected object)`
+        `At item 1: at item 0: "1" failed to typecheck (expected object)`
       ]);
     });
 
@@ -458,9 +488,9 @@ describe('schema', () => {
       expect(
         getErrors(validate({ field1: 123, field2: 'hello', field3: 1234 }))
       ).to.deep.equal([
-        'Field "field1" failed to typecheck (expected string)',
-        'Field "field2" failed to typecheck (expected number)',
-        'Field "field3" failed to typecheck (expected array)'
+        'At field "field1": 123 failed to typecheck (expected string)',
+        'At field "field2": "hello" failed to typecheck (expected number)',
+        'At field "field3": 1234 failed to typecheck (expected array)'
       ]);
     });
 

--- a/test/typecheck.spec.js
+++ b/test/typecheck.spec.js
@@ -4,7 +4,8 @@ import {
   isDate,
   isObject,
   isArray,
-  isType
+  isNull,
+  isType,
 } from '../src/lib/typecheck';
 
 describe('typecheck', () => {
@@ -82,6 +83,21 @@ describe('typecheck', () => {
     it('should succeed for arrays', () => {
       expect(isArray([])).to.be.true;
       expect(isArray([[]])).to.be.true;
+    });
+  });
+
+  describe('#isNull()', () => {
+    it('should fail for non-null values', () => {
+      expect(isNull()).to.be.false;
+      expect(isNull(2)).to.be.false;
+      expect(isNull(undefined)).to.be.false;
+      expect(isNull({})).to.be.false;
+      expect(isNull('[]')).to.be.false;
+      expect(isNull('not an array')).to.be.false;
+    });
+
+    it('should succeed for null values', () => {
+      expect(isNull(null)).to.be.true;
     });
   });
 

--- a/test/typecheck.spec.js
+++ b/test/typecheck.spec.js
@@ -4,7 +4,7 @@ import {
   isDate,
   isObject,
   isArray,
-  isType,
+  isType
 } from '../src/lib/typecheck';
 
 describe('typecheck', () => {

--- a/test/validators.spec.js
+++ b/test/validators.spec.js
@@ -13,8 +13,8 @@ import {
   validateObjPropPasses,
   validateObjOnlyHasKeys,
   validateIsArray,
+  validateArrayItems,
   validateArrayItemsHaveType,
-  validateArrayItemsPass
 } from '../src/lib/validators';
 
 describe('validators', () => {
@@ -68,7 +68,7 @@ describe('validators', () => {
       const res = validate(123);
       expect(isErr(res)).to.be.true;
       expect(getErrors(res)).to.deep.equal([
-        `123 failed to typecheck (expected string)`
+        `123 failed to typecheck (expected string)`,
       ]);
 
       expect(isErr(validateIsType('null')(true))).to.be.true;
@@ -91,7 +91,7 @@ describe('validators', () => {
       expect(isErr(validate(6))).to.be.true;
 
       expect(getErrors(validate(6))).to.deep.equal([
-        `Value must be one of 1, 2, 3, 4, 5 (got "6")`
+        `Value must be one of 1, 2, 3, 4, 5 (got "6")`,
       ]);
     });
 
@@ -107,7 +107,7 @@ describe('validators', () => {
       const res = validateIsObject('string');
       expect(isErr(res)).to.be.true;
       expect(getErrors(res)).to.deep.equal([
-        `"string" failed to typecheck (expected object)`
+        `"string" failed to typecheck (expected object)`,
       ]);
 
       expect(isErr(validateIsObject(1))).to.be.true;
@@ -127,7 +127,7 @@ describe('validators', () => {
   describe('#validateObjHasKey()', () => {
     it('should return an Err when the given data is missing required fields', () => {
       const res = validateObjHasKey('field1')({
-        field2: 'present and correct'
+        field2: 'present and correct',
       });
       expect(isErr(res)).to.be.true;
       expect(getErrors(res)).to.deep.equal([`Missing required field "field1"`]);
@@ -135,7 +135,7 @@ describe('validators', () => {
 
     it('should return an OK when the given data has all the required fields', () => {
       const res1 = validateObjHasKey('field1')({
-        field1: 'here'
+        field1: 'here',
       });
       expect(isOK(res1)).to.be.true;
       expect(getErrors(res1)).to.deep.equal([]);
@@ -145,27 +145,27 @@ describe('validators', () => {
   describe('#validateObjPropHasType()', () => {
     it('should return an Err when the given data has fields that do not typecheck', () => {
       const res1 = validateObjPropHasType('string')('field1')({
-        field1: 123
+        field1: 123,
       });
       expect(isErr(res1)).to.be.true;
       expect(getErrors(res1)).to.deep.equal([
-        `At field "field1": 123 failed to typecheck (expected string)`
+        `At field "field1": 123 failed to typecheck (expected string)`,
       ]);
 
       const res2 = validateObjPropHasType('number')('field2')({
         field1: 'a string',
-        field2: 'not a number'
+        field2: 'not a number',
       });
       expect(isErr(res2)).to.be.true;
       expect(getErrors(res2)).to.deep.equal([
-        `At field "field2": "not a number" failed to typecheck (expected number)`
+        `At field "field2": "not a number" failed to typecheck (expected number)`,
       ]);
     });
 
     it("should return an OK when the given data's fields all typecheck", () => {
       const res = validateObjPropHasType('string')('field1')({
         field1: 'a string',
-        field2: 12345
+        field2: 12345,
       });
       expect(isOK(res)).to.be.true;
       expect(getErrors(res)).to.deep.equal([]);
@@ -173,12 +173,12 @@ describe('validators', () => {
 
     it("should return an OK for fields that don't specify a type", () => {
       const res1 = validateObjPropHasType('string')('field1')({
-        field3: 'a string'
+        field3: 'a string',
       });
       expect(isOK(res1)).to.be.true;
 
       const res2 = validateObjPropHasType('string')('field1')({
-        field3: 123
+        field3: 123,
       });
       expect(isOK(res2)).to.be.true;
     });
@@ -187,22 +187,22 @@ describe('validators', () => {
   describe('#validateObjPropPasses()', () => {
     it('should check the given field validator passes', () => {
       const res1 = validateObjPropPasses(validateIsArray)('field1')({
-        field1: 123
+        field1: 123,
       });
       expect(isErr(res1)).to.be.true;
       expect(getErrors(res1)).to.deep.equal([
-        `At field "field1": 123 failed to typecheck (expected array)`
+        `At field "field1": 123 failed to typecheck (expected array)`,
       ]);
 
       const res2 = validateObjPropPasses(validateIsArray)('field1')({
-        field1: [1, 2, 3]
+        field1: [1, 2, 3],
       });
       expect(isOK(res2)).to.be.true;
     });
 
     it('should return OK if the given field is not present', () => {
       const res = validateObjPropPasses(validateIsArray)('field1')({
-        field2: 123
+        field2: 123,
       });
       expect(isOK(res)).to.be.true;
     });
@@ -211,7 +211,7 @@ describe('validators', () => {
   describe('#validateObjOnlyHasKeys', () => {
     const schema = {
       field1: {},
-      field2: {}
+      field2: {},
     };
 
     const validate = validateObjOnlyHasKeys(Object.keys(schema));
@@ -219,7 +219,7 @@ describe('validators', () => {
     it('should return an Err when the given data has extra fields', () => {
       const res1 = validate({
         field1: 'present',
-        field3: 'should not be here'
+        field3: 'should not be here',
       });
       expect(isErr(res1)).to.be.true;
       expect(getErrors(res1)).to.deep.equal([`Extra field "field3"`]);
@@ -227,7 +227,7 @@ describe('validators', () => {
       const res2 = validate({
         field1: 'present',
         field2: 'also present',
-        field3: 'should not be here'
+        field3: 'should not be here',
       });
       expect(isErr(res2)).to.be.true;
       expect(getErrors(res2)).to.deep.equal([`Extra field "field3"`]);
@@ -235,14 +235,14 @@ describe('validators', () => {
 
     it('should return an OK when the given data has no extra fields', () => {
       const res1 = validate({
-        field1: 'here'
+        field1: 'here',
       });
       expect(isOK(res1)).to.be.true;
       expect(getErrors(res1)).to.deep.equal([]);
 
       const res2 = validate({
         field1: 'here',
-        field2: 'also here'
+        field2: 'also here',
       });
       expect(isOK(res2)).to.be.true;
       expect(getErrors(res2)).to.deep.equal([]);
@@ -254,7 +254,7 @@ describe('validators', () => {
       const res = validateIsArray('string');
       expect(isErr(res)).to.be.true;
       expect(getErrors(res)).to.deep.equal([
-        `"string" failed to typecheck (expected array)`
+        `"string" failed to typecheck (expected array)`,
       ]);
 
       expect(isErr(validateIsArray(1))).to.be.true;
@@ -278,13 +278,13 @@ describe('validators', () => {
       const res1 = validate([1, '2', '3']);
       expect(isErr(res1)).to.be.true;
       expect(getErrors(res1)).to.deep.equal([
-        `At item 0: 1 failed to typecheck (expected string)`
+        `At item 0: 1 failed to typecheck (expected string)`,
       ]);
 
       const res2 = validate(['1', true]);
       expect(isErr(res2)).to.be.true;
       expect(getErrors(res2)).to.deep.equal([
-        `At item 1: true failed to typecheck (expected string)`
+        `At item 1: true failed to typecheck (expected string)`,
       ]);
     });
 
@@ -297,17 +297,15 @@ describe('validators', () => {
     });
   });
 
-  describe('#validateArrayItemsPass()', () => {
-    const validate = validateArrayItemsPass(
-      n => (n > 3 ? ok() : err(`${n} <= 3`))
-    );
+  describe('#validateArrayItems()', () => {
+    const validate = validateArrayItems(n => (n > 3 ? ok() : err(`${n} <= 3`)));
 
     it('should return an Err if any of the items fail the given validator', () => {
       const res = validate([2, 3, 4]);
       expect(isErr(res)).to.be.true;
       expect(getErrors(res)).to.deep.equal([
         `At item 0: 2 <= 3`,
-        `At item 1: 3 <= 3`
+        `At item 1: 3 <= 3`,
       ]);
     });
 

--- a/test/validators.spec.js
+++ b/test/validators.spec.js
@@ -299,7 +299,7 @@ describe('validators', () => {
 
   describe('#validateArrayItemsPass()', () => {
     const validate = validateArrayItemsPass(
-      n => (n > 3 ? ok() : err([`${n} <= 3`]))
+      n => (n > 3 ? ok() : err(`${n} <= 3`))
     );
 
     it('should return an Err if any of the items fail the given validator', () => {

--- a/test/validators.spec.js
+++ b/test/validators.spec.js
@@ -149,7 +149,7 @@ describe('validators', () => {
       });
       expect(isErr(res1)).to.be.true;
       expect(getErrors(res1)).to.deep.equal([
-        `Field "field1" failed to typecheck (expected string)`
+        `At field "field1": 123 failed to typecheck (expected string)`
       ]);
 
       const res2 = validateObjPropHasType('number')('field2')({
@@ -158,7 +158,7 @@ describe('validators', () => {
       });
       expect(isErr(res2)).to.be.true;
       expect(getErrors(res2)).to.deep.equal([
-        `Field "field2" failed to typecheck (expected number)`
+        `At field "field2": "not a number" failed to typecheck (expected number)`
       ]);
     });
 
@@ -278,13 +278,13 @@ describe('validators', () => {
       const res1 = validate([1, '2', '3']);
       expect(isErr(res1)).to.be.true;
       expect(getErrors(res1)).to.deep.equal([
-        `Item "1" failed to typecheck (expected string)`
+        `At item 0: "1" failed to typecheck (expected string)`
       ]);
 
       const res2 = validate(['1', true]);
       expect(isErr(res2)).to.be.true;
       expect(getErrors(res2)).to.deep.equal([
-        `Item "true" failed to typecheck (expected string)`
+        `At item 1: "true" failed to typecheck (expected string)`
       ]);
     });
 

--- a/test/validators.spec.js
+++ b/test/validators.spec.js
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
-import { isOK, isErr, ok, err, getErrors } from '../src/lib/result';
+import { getErrors } from '../src/lib/printer';
+import { isOK, isErr, ok, err } from '../src/lib/result';
 import {
   alwaysErr,
   alwaysOK,
@@ -13,7 +14,7 @@ import {
   validateObjOnlyHasKeys,
   validateIsArray,
   validateArrayItemsHaveType,
-  validateArrayItemsPass,
+  validateArrayItemsPass
 } from '../src/lib/validators';
 
 describe('validators', () => {
@@ -67,7 +68,7 @@ describe('validators', () => {
       const res = validate(123);
       expect(isErr(res)).to.be.true;
       expect(getErrors(res)).to.deep.equal([
-        `"123" failed to typecheck (expected string)`,
+        `"123" failed to typecheck (expected string)`
       ]);
 
       expect(isErr(validateIsType('null')(true))).to.be.true;
@@ -90,7 +91,7 @@ describe('validators', () => {
       expect(isErr(validate(6))).to.be.true;
 
       expect(getErrors(validate(6))).to.deep.equal([
-        `Value must be one of 1, 2, 3, 4, 5 (got "6")`,
+        `Value must be one of 1, 2, 3, 4, 5 (got "6")`
       ]);
     });
 
@@ -106,7 +107,7 @@ describe('validators', () => {
       const res = validateIsObject('string');
       expect(isErr(res)).to.be.true;
       expect(getErrors(res)).to.deep.equal([
-        `"string" failed to typecheck (expected object)`,
+        `"string" failed to typecheck (expected object)`
       ]);
 
       expect(isErr(validateIsObject(1))).to.be.true;
@@ -126,7 +127,7 @@ describe('validators', () => {
   describe('#validateObjHasKey()', () => {
     it('should return an Err when the given data is missing required fields', () => {
       const res = validateObjHasKey('field1')({
-        field2: 'present and correct',
+        field2: 'present and correct'
       });
       expect(isErr(res)).to.be.true;
       expect(getErrors(res)).to.deep.equal([`Missing required field "field1"`]);
@@ -134,7 +135,7 @@ describe('validators', () => {
 
     it('should return an OK when the given data has all the required fields', () => {
       const res1 = validateObjHasKey('field1')({
-        field1: 'here',
+        field1: 'here'
       });
       expect(isOK(res1)).to.be.true;
       expect(getErrors(res1)).to.deep.equal([]);
@@ -144,27 +145,27 @@ describe('validators', () => {
   describe('#validateObjPropHasType()', () => {
     it('should return an Err when the given data has fields that do not typecheck', () => {
       const res1 = validateObjPropHasType('string')('field1')({
-        field1: 123,
+        field1: 123
       });
       expect(isErr(res1)).to.be.true;
       expect(getErrors(res1)).to.deep.equal([
-        `Field "field1" failed to typecheck (expected string)`,
+        `Field "field1" failed to typecheck (expected string)`
       ]);
 
       const res2 = validateObjPropHasType('number')('field2')({
         field1: 'a string',
-        field2: 'not a number',
+        field2: 'not a number'
       });
       expect(isErr(res2)).to.be.true;
       expect(getErrors(res2)).to.deep.equal([
-        `Field "field2" failed to typecheck (expected number)`,
+        `Field "field2" failed to typecheck (expected number)`
       ]);
     });
 
     it("should return an OK when the given data's fields all typecheck", () => {
       const res = validateObjPropHasType('string')('field1')({
         field1: 'a string',
-        field2: 12345,
+        field2: 12345
       });
       expect(isOK(res)).to.be.true;
       expect(getErrors(res)).to.deep.equal([]);
@@ -172,12 +173,12 @@ describe('validators', () => {
 
     it("should return an OK for fields that don't specify a type", () => {
       const res1 = validateObjPropHasType('string')('field1')({
-        field3: 'a string',
+        field3: 'a string'
       });
       expect(isOK(res1)).to.be.true;
 
       const res2 = validateObjPropHasType('string')('field1')({
-        field3: 123,
+        field3: 123
       });
       expect(isOK(res2)).to.be.true;
     });
@@ -186,22 +187,22 @@ describe('validators', () => {
   describe('#validateObjPropPasses()', () => {
     it('should check the given field validator passes', () => {
       const res1 = validateObjPropPasses(validateIsArray)('field1')({
-        field1: 123,
+        field1: 123
       });
       expect(isErr(res1)).to.be.true;
       expect(getErrors(res1)).to.deep.equal([
-        `At field "field1": "123" failed to typecheck (expected array)`,
+        `At field "field1": "123" failed to typecheck (expected array)`
       ]);
 
       const res2 = validateObjPropPasses(validateIsArray)('field1')({
-        field1: [1, 2, 3],
+        field1: [1, 2, 3]
       });
       expect(isOK(res2)).to.be.true;
     });
 
     it('should return OK if the given field is not present', () => {
       const res = validateObjPropPasses(validateIsArray)('field1')({
-        field2: 123,
+        field2: 123
       });
       expect(isOK(res)).to.be.true;
     });
@@ -210,7 +211,7 @@ describe('validators', () => {
   describe('#validateObjOnlyHasKeys', () => {
     const schema = {
       field1: {},
-      field2: {},
+      field2: {}
     };
 
     const validate = validateObjOnlyHasKeys(Object.keys(schema));
@@ -218,7 +219,7 @@ describe('validators', () => {
     it('should return an Err when the given data has extra fields', () => {
       const res1 = validate({
         field1: 'present',
-        field3: 'should not be here',
+        field3: 'should not be here'
       });
       expect(isErr(res1)).to.be.true;
       expect(getErrors(res1)).to.deep.equal([`Extra field "field3"`]);
@@ -226,7 +227,7 @@ describe('validators', () => {
       const res2 = validate({
         field1: 'present',
         field2: 'also present',
-        field3: 'should not be here',
+        field3: 'should not be here'
       });
       expect(isErr(res2)).to.be.true;
       expect(getErrors(res2)).to.deep.equal([`Extra field "field3"`]);
@@ -234,14 +235,14 @@ describe('validators', () => {
 
     it('should return an OK when the given data has no extra fields', () => {
       const res1 = validate({
-        field1: 'here',
+        field1: 'here'
       });
       expect(isOK(res1)).to.be.true;
       expect(getErrors(res1)).to.deep.equal([]);
 
       const res2 = validate({
         field1: 'here',
-        field2: 'also here',
+        field2: 'also here'
       });
       expect(isOK(res2)).to.be.true;
       expect(getErrors(res2)).to.deep.equal([]);
@@ -253,7 +254,7 @@ describe('validators', () => {
       const res = validateIsArray('string');
       expect(isErr(res)).to.be.true;
       expect(getErrors(res)).to.deep.equal([
-        `"string" failed to typecheck (expected array)`,
+        `"string" failed to typecheck (expected array)`
       ]);
 
       expect(isErr(validateIsArray(1))).to.be.true;
@@ -277,13 +278,13 @@ describe('validators', () => {
       const res1 = validate([1, '2', '3']);
       expect(isErr(res1)).to.be.true;
       expect(getErrors(res1)).to.deep.equal([
-        `Item "1" failed to typecheck (expected string)`,
+        `Item "1" failed to typecheck (expected string)`
       ]);
 
       const res2 = validate(['1', true]);
       expect(isErr(res2)).to.be.true;
       expect(getErrors(res2)).to.deep.equal([
-        `Item "true" failed to typecheck (expected string)`,
+        `Item "true" failed to typecheck (expected string)`
       ]);
     });
 
@@ -306,7 +307,7 @@ describe('validators', () => {
       expect(isErr(res)).to.be.true;
       expect(getErrors(res)).to.deep.equal([
         `At item 0: 2 <= 3`,
-        `At item 1: 3 <= 3`,
+        `At item 1: 3 <= 3`
       ]);
     });
 

--- a/test/validators.spec.js
+++ b/test/validators.spec.js
@@ -68,7 +68,7 @@ describe('validators', () => {
       const res = validate(123);
       expect(isErr(res)).to.be.true;
       expect(getErrors(res)).to.deep.equal([
-        `"123" failed to typecheck (expected string)`
+        `123 failed to typecheck (expected string)`
       ]);
 
       expect(isErr(validateIsType('null')(true))).to.be.true;
@@ -191,7 +191,7 @@ describe('validators', () => {
       });
       expect(isErr(res1)).to.be.true;
       expect(getErrors(res1)).to.deep.equal([
-        `At field "field1": "123" failed to typecheck (expected array)`
+        `At field "field1": 123 failed to typecheck (expected array)`
       ]);
 
       const res2 = validateObjPropPasses(validateIsArray)('field1')({
@@ -278,13 +278,13 @@ describe('validators', () => {
       const res1 = validate([1, '2', '3']);
       expect(isErr(res1)).to.be.true;
       expect(getErrors(res1)).to.deep.equal([
-        `At item 0: "1" failed to typecheck (expected string)`
+        `At item 0: 1 failed to typecheck (expected string)`
       ]);
 
       const res2 = validate(['1', true]);
       expect(isErr(res2)).to.be.true;
       expect(getErrors(res2)).to.deep.equal([
-        `At item 1: "true" failed to typecheck (expected string)`
+        `At item 1: true failed to typecheck (expected string)`
       ]);
     });
 

--- a/test/validators.spec.js
+++ b/test/validators.spec.js
@@ -9,6 +9,7 @@ import {
   validateIsIn,
   validateIsObject,
   validateObjHasKey,
+  validateObjFields,
   validateObjPropHasType,
   validateObjPropPasses,
   validateObjOnlyHasKeys,
@@ -142,6 +143,23 @@ describe('validators', () => {
     });
   });
 
+  describe('#validateObjFields()', () => {
+    const validate = validateObjFields(
+      fromPredicate(n => n === 5, n => `${n} != 5`)
+    );
+
+    it('should return an Err if any object fields do not pass the validator', () => {
+      const res = validate({ a: 1, b: 5 });
+      expect(isErr(res)).to.be.true;
+      expect(getErrors(res)).to.deep.equal(['At field "a": 1 != 5']);
+    });
+
+    it('should return an OK if all the object fields pass the validator', () => {
+      const res = validate({ a: 5, b: 5 });
+      expect(isOK(res)).to.be.true;
+    });
+  });
+
   describe('#validateObjPropHasType()', () => {
     it('should return an Err when the given data has fields that do not typecheck', () => {
       const res1 = validateObjPropHasType('string')('field1')({
@@ -271,6 +289,24 @@ describe('validators', () => {
     });
   });
 
+  describe('#validateArrayItems()', () => {
+    const validate = validateArrayItems(n => (n > 3 ? ok() : err(`${n} <= 3`)));
+
+    it('should return an Err if any of the items fail the given validator', () => {
+      const res = validate([2, 3, 4]);
+      expect(isErr(res)).to.be.true;
+      expect(getErrors(res)).to.deep.equal([
+        `At item 0: 2 <= 3`,
+        `At item 1: 3 <= 3`,
+      ]);
+    });
+
+    it('should return OK if all the items pass the given validator', () => {
+      const res = validate([4, 5, 6]);
+      expect(isOK(res)).to.be.true;
+    });
+  });
+
   describe('#validateArrayItemsHaveType()', () => {
     it('should return an Err when the given array has items that do not typecheck', () => {
       const validate = validateArrayItemsHaveType('string');
@@ -294,24 +330,6 @@ describe('validators', () => {
       const res = validate(['1', '2']);
       expect(isOK(res)).to.be.true;
       expect(getErrors(res)).to.deep.equal([]);
-    });
-  });
-
-  describe('#validateArrayItems()', () => {
-    const validate = validateArrayItems(n => (n > 3 ? ok() : err(`${n} <= 3`)));
-
-    it('should return an Err if any of the items fail the given validator', () => {
-      const res = validate([2, 3, 4]);
-      expect(isErr(res)).to.be.true;
-      expect(getErrors(res)).to.deep.equal([
-        `At item 0: 2 <= 3`,
-        `At item 1: 3 <= 3`,
-      ]);
-    });
-
-    it('should return OK if all the items pass the given validator', () => {
-      const res = validate([4, 5, 6]);
-      expect(isOK(res)).to.be.true;
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,96 @@
 # yarn lockfile v1
 
 
+"@babel/code-frame@7.0.0-beta.40", "@babel/code-frame@^7.0.0-beta.40":
+  version "7.0.0-beta.40"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.40.tgz#37e2b0cf7c56026b4b21d3927cadf81adec32ac6"
+  dependencies:
+    "@babel/highlight" "7.0.0-beta.40"
+
+"@babel/generator@7.0.0-beta.40":
+  version "7.0.0-beta.40"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.0.0-beta.40.tgz#ab61f9556f4f71dbd1138949c795bb9a21e302ea"
+  dependencies:
+    "@babel/types" "7.0.0-beta.40"
+    jsesc "^2.5.1"
+    lodash "^4.2.0"
+    source-map "^0.5.0"
+    trim-right "^1.0.1"
+
+"@babel/helper-function-name@7.0.0-beta.40":
+  version "7.0.0-beta.40"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.40.tgz#9d033341ab16517f40d43a73f2d81fc431ccd7b6"
+  dependencies:
+    "@babel/helper-get-function-arity" "7.0.0-beta.40"
+    "@babel/template" "7.0.0-beta.40"
+    "@babel/types" "7.0.0-beta.40"
+
+"@babel/helper-get-function-arity@7.0.0-beta.40":
+  version "7.0.0-beta.40"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.40.tgz#ac0419cf067b0ec16453e1274f03878195791c6e"
+  dependencies:
+    "@babel/types" "7.0.0-beta.40"
+
+"@babel/highlight@7.0.0-beta.40":
+  version "7.0.0-beta.40"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0-beta.40.tgz#b43d67d76bf46e1d10d227f68cddcd263786b255"
+  dependencies:
+    chalk "^2.0.0"
+    esutils "^2.0.2"
+    js-tokens "^3.0.0"
+
+"@babel/template@7.0.0-beta.40":
+  version "7.0.0-beta.40"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.40.tgz#034988c6424eb5c3268fe6a608626de1f4410fc8"
+  dependencies:
+    "@babel/code-frame" "7.0.0-beta.40"
+    "@babel/types" "7.0.0-beta.40"
+    babylon "7.0.0-beta.40"
+    lodash "^4.2.0"
+
+"@babel/traverse@^7.0.0-beta.40":
+  version "7.0.0-beta.40"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.0.0-beta.40.tgz#d140e449b2e093ef9fe1a2eecc28421ffb4e521e"
+  dependencies:
+    "@babel/code-frame" "7.0.0-beta.40"
+    "@babel/generator" "7.0.0-beta.40"
+    "@babel/helper-function-name" "7.0.0-beta.40"
+    "@babel/types" "7.0.0-beta.40"
+    babylon "7.0.0-beta.40"
+    debug "^3.0.1"
+    globals "^11.1.0"
+    invariant "^2.2.0"
+    lodash "^4.2.0"
+
+"@babel/types@7.0.0-beta.40", "@babel/types@^7.0.0-beta.40":
+  version "7.0.0-beta.40"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.40.tgz#25c3d7aae14126abe05fcb098c65a66b6d6b8c14"
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.2.0"
+    to-fast-properties "^2.0.0"
+
 abbrev@1, abbrev@1.0.x:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.0.9.tgz#91b4792588a7738c25f35dd6f63752a2f8776135"
+
+acorn-jsx@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
+  dependencies:
+    acorn "^3.0.4"
+
+acorn@^3.0.4:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
+
+acorn@^5.5.0:
+  version "5.5.3"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.5.3.tgz#f473dd47e0277a08e28e9bec5aeeb04751f0b8c9"
+
+ajv-keywords@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.1.tgz#617997fc5f60576894c435f940d819e135b80762"
 
 ajv@^4.9.1:
   version "4.11.8"
@@ -12,6 +99,15 @@ ajv@^4.9.1:
   dependencies:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
+
+ajv@^5.2.3, ajv@^5.3.0:
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
+  dependencies:
+    co "^4.6.0"
+    fast-deep-equal "^1.0.0"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.3.0"
 
 align-text@^0.1.1, align-text@^0.1.3:
   version "0.1.4"
@@ -25,13 +121,27 @@ amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
 
+ansi-escapes@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.0.0.tgz#ec3e8b4e9f8064fc02c3ac9b65f1c275bda8ef92"
+
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
 
+ansi-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
+
 ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
+
+ansi-styles@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
+  dependencies:
+    color-convert "^1.9.0"
 
 anymatch@^1.3.0:
   version "1.3.0"
@@ -76,6 +186,16 @@ arr-diff@^2.0.0:
 arr-flatten@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.0.3.tgz#a274ed85ac08849b6bd7847c4580745dc51adfb1"
+
+array-union@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
+  dependencies:
+    array-uniq "^1.0.1"
+
+array-uniq@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
 
 array-unique@^0.2.1:
   version "0.2.1"
@@ -173,6 +293,17 @@ babel-core@^6.24.1, babel-core@^6.25.0:
     private "^0.1.6"
     slash "^1.0.0"
     source-map "^0.5.0"
+
+babel-eslint@^8.2.2:
+  version "8.2.2"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-8.2.2.tgz#1102273354c6f0b29b4ea28a65f97d122296b68b"
+  dependencies:
+    "@babel/code-frame" "^7.0.0-beta.40"
+    "@babel/traverse" "^7.0.0-beta.40"
+    "@babel/types" "^7.0.0-beta.40"
+    babylon "^7.0.0-beta.40"
+    eslint-scope "~3.7.1"
+    eslint-visitor-keys "^1.0.0"
 
 babel-generator@^6.18.0, babel-generator@^6.25.0:
   version "6.25.0"
@@ -586,6 +717,10 @@ babelrc-rollup@^3.0.0:
   dependencies:
     resolve "^1.1.7"
 
+babylon@7.0.0-beta.40, babylon@^7.0.0-beta.40:
+  version "7.0.0-beta.40"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.40.tgz#91fc8cd56d5eb98b28e6fde41045f2957779940a"
+
 babylon@^6.13.0, babylon@^6.17.2:
   version "6.17.4"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.4.tgz#3e8b7402b88d22c3423e137a1577883b15ff869a"
@@ -593,6 +728,10 @@ babylon@^6.13.0, babylon@^6.17.2:
 balanced-match@^0.4.1:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"
+
+balanced-match@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
 bcrypt-pbkdf@^1.0.0:
   version "1.0.1"
@@ -623,6 +762,13 @@ brace-expansion@^1.0.0:
     balanced-match "^0.4.1"
     concat-map "0.0.1"
 
+brace-expansion@^1.1.7:
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
+  dependencies:
+    balanced-match "^1.0.0"
+    concat-map "0.0.1"
+
 braces@^1.8.2:
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/braces/-/braces-1.8.5.tgz#ba77962e12dff969d6b76711e914b737857bf6a7"
@@ -646,6 +792,16 @@ caching-transform@^1.0.0:
     md5-hex "^1.2.0"
     mkdirp "^0.5.1"
     write-file-atomic "^1.1.4"
+
+caller-path@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"
+  dependencies:
+    callsites "^0.2.0"
+
+callsites@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/callsites/-/callsites-0.2.0.tgz#afab96262910a7f33c19a5775825c69f34e350ca"
 
 camelcase@^1.0.2:
   version "1.2.1"
@@ -688,6 +844,18 @@ chalk@^1.1.0:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
+chalk@^2.0.0, chalk@^2.1.0:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.2.tgz#250dc96b07491bfd601e648d66ddf5f60c7a5c65"
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
+
+chardet@^0.4.0:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
+
 chokidar@^1.6.1:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.7.0.tgz#798e689778151c8076b4b360e5edd28cda2bb468"
@@ -702,6 +870,20 @@ chokidar@^1.6.1:
     readdirp "^2.0.0"
   optionalDependencies:
     fsevents "^1.0.0"
+
+circular-json@^0.3.1:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"
+
+cli-cursor@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
+  dependencies:
+    restore-cursor "^2.0.0"
+
+cli-width@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
 
 cliui@^2.1.0:
   version "2.1.0"
@@ -727,6 +909,16 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
+color-convert@^1.9.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.1.tgz#c1261107aeb2f294ebffec9ed9ecad529a6097ed"
+  dependencies:
+    color-name "^1.1.1"
+
+color-name@^1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
+
 combined-stream@^1.0.5, combined-stream@~1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.5.tgz#938370a57b4a51dea2c77c15d5c5fdf895164009"
@@ -746,6 +938,14 @@ commondir@^1.0.1:
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+
+concat-stream@^1.6.0:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.1.tgz#261b8f518301f1d834e36342b9fea095d2620a26"
+  dependencies:
+    inherits "^2.0.3"
+    readable-stream "^2.2.2"
+    typedarray "^0.0.6"
 
 console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
@@ -768,6 +968,14 @@ cross-spawn@^4, cross-spawn@^4.0.0:
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
   dependencies:
     lru-cache "^4.0.1"
+    which "^1.2.9"
+
+cross-spawn@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
+  dependencies:
+    lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
     which "^1.2.9"
 
 cryptiles@2.x.x:
@@ -798,6 +1006,12 @@ debug@^2.6.3:
   dependencies:
     ms "2.0.0"
 
+debug@^3.0.1, debug@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  dependencies:
+    ms "2.0.0"
+
 decamelize@^1.0.0, decamelize@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
@@ -822,6 +1036,18 @@ default-require-extensions@^1.0.0:
   dependencies:
     strip-bom "^2.0.0"
 
+del@^2.0.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/del/-/del-2.2.2.tgz#c12c981d067846c84bcaf862cff930d907ffd1a8"
+  dependencies:
+    globby "^5.0.0"
+    is-path-cwd "^1.0.0"
+    is-path-in-cwd "^1.0.0"
+    object-assign "^4.0.1"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
+    rimraf "^2.2.8"
+
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
@@ -840,6 +1066,12 @@ diff@3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
 
+doctrine@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
+  dependencies:
+    esutils "^2.0.2"
+
 ecc-jsbn@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
@@ -852,7 +1084,7 @@ error-ex@^1.2.0:
   dependencies:
     is-arrayish "^0.2.1"
 
-escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2:
+escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
@@ -867,6 +1099,76 @@ escodegen@1.8.x:
   optionalDependencies:
     source-map "~0.2.0"
 
+eslint-plugin-flowtype@^2.46.1:
+  version "2.46.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.46.1.tgz#c4f81d580cd89c82bc3a85a1ccf4ae3a915143a4"
+  dependencies:
+    lodash "^4.15.0"
+
+eslint-plugin-promise@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-3.6.0.tgz#54b7658c8f454813dc2a870aff8152ec4969ba75"
+
+eslint-scope@^3.7.1, eslint-scope@~3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
+eslint-visitor-keys@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
+
+eslint@^4.18.2:
+  version "4.18.2"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.18.2.tgz#0f81267ad1012e7d2051e186a9004cc2267b8d45"
+  dependencies:
+    ajv "^5.3.0"
+    babel-code-frame "^6.22.0"
+    chalk "^2.1.0"
+    concat-stream "^1.6.0"
+    cross-spawn "^5.1.0"
+    debug "^3.1.0"
+    doctrine "^2.1.0"
+    eslint-scope "^3.7.1"
+    eslint-visitor-keys "^1.0.0"
+    espree "^3.5.2"
+    esquery "^1.0.0"
+    esutils "^2.0.2"
+    file-entry-cache "^2.0.0"
+    functional-red-black-tree "^1.0.1"
+    glob "^7.1.2"
+    globals "^11.0.1"
+    ignore "^3.3.3"
+    imurmurhash "^0.1.4"
+    inquirer "^3.0.6"
+    is-resolvable "^1.0.0"
+    js-yaml "^3.9.1"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.3.0"
+    lodash "^4.17.4"
+    minimatch "^3.0.2"
+    mkdirp "^0.5.1"
+    natural-compare "^1.4.0"
+    optionator "^0.8.2"
+    path-is-inside "^1.0.2"
+    pluralize "^7.0.0"
+    progress "^2.0.0"
+    require-uncached "^1.0.3"
+    semver "^5.3.0"
+    strip-ansi "^4.0.0"
+    strip-json-comments "~2.0.1"
+    table "4.0.2"
+    text-table "~0.2.0"
+
+espree@^3.5.2:
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.4.tgz#b0f447187c8a8bed944b815a660bddf5deb5d1a7"
+  dependencies:
+    acorn "^5.5.0"
+    acorn-jsx "^3.0.0"
+
 esprima@2.7.x, esprima@^2.7.1:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
@@ -875,9 +1177,29 @@ esprima@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
 
+esprima@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
+
+esquery@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.0.tgz#cfba8b57d7fba93f17298a8a006a04cda13d80fa"
+  dependencies:
+    estraverse "^4.0.0"
+
+esrecurse@^4.1.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.2.1.tgz#007a3b9fdbc2b3bb87e4879ea19c92fdbd3942cf"
+  dependencies:
+    estraverse "^4.1.0"
+
 estraverse@^1.9.1:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-1.9.3.tgz#af67f2dc922582415950926091a4005d29c9bb44"
+
+estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
 
 estree-walker@^0.2.1:
   version "0.2.1"
@@ -915,6 +1237,14 @@ extend@~3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
+external-editor@^2.0.4:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.1.0.tgz#3d026a21b7f95b5726387d4200ac160d372c3b48"
+  dependencies:
+    chardet "^0.4.0"
+    iconv-lite "^0.4.17"
+    tmp "^0.0.33"
+
 extglob@^0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-0.3.2.tgz#2e18ff3d2f49ab2765cec9023f011daa8d8349a1"
@@ -925,9 +1255,30 @@ extsprintf@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.0.2.tgz#e1080e0658e300b06294990cc70e1502235fd550"
 
+fast-deep-equal@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
+
+fast-json-stable-stringify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
+
 fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
+
+figures@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
+  dependencies:
+    escape-string-regexp "^1.0.5"
+
+file-entry-cache@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-2.0.0.tgz#c392990c3e684783d838b8c84a45d8a048458361"
+  dependencies:
+    flat-cache "^1.2.1"
+    object-assign "^4.0.1"
 
 filename-regex@^2.0.0:
   version "2.0.1"
@@ -963,6 +1314,15 @@ find-up@^2.0.0, find-up@^2.1.0:
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
   dependencies:
     locate-path "^2.0.0"
+
+flat-cache@^1.2.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-1.3.0.tgz#d3030b32b38154f4e3b7e9c709f490f7ef97c481"
+  dependencies:
+    circular-json "^0.3.1"
+    del "^2.0.2"
+    graceful-fs "^4.1.2"
+    write "^0.2.1"
 
 flow-bin@^0.48.0:
   version "0.48.0"
@@ -1029,6 +1389,10 @@ fstream@^1.0.0, fstream@^1.0.10, fstream@^1.0.2:
     mkdirp ">=0.5 0"
     rimraf "2"
 
+functional-red-black-tree@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
+
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
@@ -1093,9 +1457,35 @@ glob@^5.0.15:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@^7.0.3, glob@^7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+globals@^11.0.1, globals@^11.1.0:
+  version "11.3.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.3.0.tgz#e04fdb7b9796d8adac9c8f64c14837b2313378b0"
+
 globals@^9.0.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
+
+globby@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-5.0.0.tgz#ebd84667ca0dbb330b99bcfc68eac2bc54370e0d"
+  dependencies:
+    array-union "^1.0.1"
+    arrify "^1.0.0"
+    glob "^7.0.3"
+    object-assign "^4.0.1"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.4:
   version "4.1.11"
@@ -1140,6 +1530,10 @@ has-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
 
+has-flag@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+
 has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
@@ -1176,6 +1570,14 @@ http-signature@~1.1.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
+iconv-lite@^0.4.17:
+  version "0.4.19"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
+
+ignore@^3.3.3:
+  version "3.3.7"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.7.tgz#612289bfb3c220e186a58118618d5be8c1bab021"
+
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
@@ -1187,13 +1589,32 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.1, inherits@~2.0.0, inherits@~2.0.3:
+inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
 ini@~1.3.0:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
+
+inquirer@^3.0.6:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.3.0.tgz#9dd2f2ad765dcab1ff0443b491442a20ba227dc9"
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.0"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^2.0.4"
+    figures "^2.0.0"
+    lodash "^4.3.0"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rx-lite "^4.0.8"
+    rx-lite-aggregates "^4.0.8"
+    string-width "^2.1.0"
+    strip-ansi "^4.0.0"
+    through "^2.3.6"
 
 invariant@^2.2.0:
   version "2.2.2"
@@ -1277,6 +1698,22 @@ is-number@^3.0.0:
   dependencies:
     kind-of "^3.0.2"
 
+is-path-cwd@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-1.0.0.tgz#d225ec23132e89edd38fda767472e62e65f1106d"
+
+is-path-in-cwd@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz#6477582b8214d602346094567003be8a9eac04dc"
+  dependencies:
+    is-path-inside "^1.0.0"
+
+is-path-inside@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.1.tgz#8ef5b7de50437a3fdca6b4e865ef7aa55cb48036"
+  dependencies:
+    path-is-inside "^1.0.1"
+
 is-posix-bracket@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz#3334dc79774368e92f016e6fbc0a88f5cd6e6bc4"
@@ -1284,6 +1721,14 @@ is-posix-bracket@^0.1.0:
 is-primitive@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
+
+is-promise@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
+
+is-resolvable@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
 
 is-stream@^1.1.0:
   version "1.1.0"
@@ -1392,6 +1837,13 @@ js-yaml@3.x:
     argparse "^1.0.7"
     esprima "^3.1.1"
 
+js-yaml@^3.9.1:
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.11.0.tgz#597c1a8bd57152f26d622ce4117851a51f5ebaef"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
@@ -1400,13 +1852,25 @@ jsesc@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-1.3.0.tgz#46c3fec8c1892b12b0833db9bc7622176dbab34b"
 
+jsesc@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.1.tgz#e421a2a8e20d6b0819df28908f782526b96dd1fe"
+
 jsesc@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
 
+json-schema-traverse@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"
+
 json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
+
+json-stable-stringify-without-jsonify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
 
 json-stable-stringify@^1.0.1:
   version "1.0.1"
@@ -1461,7 +1925,7 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
-levn@~0.3.0:
+levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
   dependencies:
@@ -1540,6 +2004,10 @@ lodash.keys@^3.0.0:
     lodash._getnative "^3.0.0"
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
+
+lodash@^4.15.0, lodash@^4.17.4, lodash@^4.3.0:
+  version "4.17.5"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 
 lodash@^4.2.0:
   version "4.17.4"
@@ -1622,6 +2090,12 @@ mimic-fn@^1.0.0:
   dependencies:
     brace-expansion "^1.0.0"
 
+minimatch@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
+  dependencies:
+    brace-expansion "^1.1.7"
+
 minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
@@ -1660,9 +2134,17 @@ ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
+mute-stream@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
+
 nan@^2.3.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.6.2.tgz#e4ff34e6c95fdfb5aecc08de6596f43605a7db45"
+
+natural-compare@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
 node-pre-gyp@^0.6.36:
   version "0.6.36"
@@ -1778,6 +2260,12 @@ once@1.x, once@^1.3.0, once@^1.3.3:
   dependencies:
     wrappy "1"
 
+onetime@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
+  dependencies:
+    mimic-fn "^1.0.0"
+
 optimist@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686"
@@ -1785,7 +2273,7 @@ optimist@^0.6.1:
     minimist "~0.0.1"
     wordwrap "~0.0.2"
 
-optionator@^0.8.1:
+optionator@^0.8.1, optionator@^0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
   dependencies:
@@ -1808,7 +2296,7 @@ os-locale@^2.0.0:
     lcid "^1.0.0"
     mem "^1.1.0"
 
-os-tmpdir@^1.0.0, os-tmpdir@^1.0.1:
+os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
 
@@ -1870,6 +2358,10 @@ path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
+path-is-inside@^1.0.1, path-is-inside@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
+
 path-key@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
@@ -1916,6 +2408,10 @@ pkg-dir@^1.0.0:
   dependencies:
     find-up "^1.0.0"
 
+pluralize@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -1931,6 +2427,14 @@ private@^0.1.6:
 process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
+
+process-nextick-args@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
+
+progress@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
 
 pseudomap@^1.0.2:
   version "1.0.2"
@@ -2004,6 +2508,18 @@ readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.4:
     process-nextick-args "~1.0.6"
     safe-buffer "~5.1.0"
     string_decoder "~1.0.0"
+    util-deprecate "~1.0.1"
+
+readable-stream@^2.2.2:
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.5.tgz#b4f85003a938cbb6ecbce2a124fb1012bd1a838d"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.0.3"
     util-deprecate "~1.0.1"
 
 readdirp@^2.0.0:
@@ -2109,6 +2625,17 @@ require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
 
+require-uncached@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/require-uncached/-/require-uncached-1.0.3.tgz#4e0d56d6c9662fd31e43011c4b95aa49955421d3"
+  dependencies:
+    caller-path "^0.1.0"
+    resolve-from "^1.0.0"
+
+resolve-from@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
+
 resolve-from@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-2.0.0.tgz#9480ab20e94ffa1d9e80a804c7ea147611966b57"
@@ -2123,6 +2650,13 @@ resolve@^1.1.7:
   dependencies:
     path-parse "^1.0.5"
 
+restore-cursor@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"
+  dependencies:
+    onetime "^2.0.0"
+    signal-exit "^3.0.2"
+
 right-align@^0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/right-align/-/right-align-0.1.3.tgz#61339b722fe6a3515689210d24e14c96148613ef"
@@ -2132,6 +2666,12 @@ right-align@^0.1.1:
 rimraf@2, rimraf@^2.3.3, rimraf@^2.5.1, rimraf@^2.5.4, rimraf@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
+  dependencies:
+    glob "^7.0.5"
+
+rimraf@^2.2.8:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:
     glob "^7.0.5"
 
@@ -2152,7 +2692,23 @@ rollup@^0.47.4:
   version "0.47.4"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.47.4.tgz#e3a55de83a78221d232ce29619a8d68189ae845e"
 
-safe-buffer@^5.0.1, safe-buffer@~5.1.0:
+run-async@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
+  dependencies:
+    is-promise "^2.1.0"
+
+rx-lite-aggregates@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz#753b87a89a11c95467c4ac1626c4efc4e05c67be"
+  dependencies:
+    rx-lite "*"
+
+rx-lite@*, rx-lite@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
+
+safe-buffer@^5.0.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
@@ -2168,6 +2724,16 @@ set-immediate-shim@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
 
+shebang-command@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
+  dependencies:
+    shebang-regex "^1.0.0"
+
+shebang-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
+
 signal-exit@^3.0.0, signal-exit@^3.0.1, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
@@ -2175,6 +2741,12 @@ signal-exit@^3.0.0, signal-exit@^3.0.1, signal-exit@^3.0.2:
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
+
+slice-ansi@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-1.0.0.tgz#044f1a49d8842ff307aad6b505ed178bd950134d"
+  dependencies:
+    is-fullwidth-code-point "^2.0.0"
 
 slide@^1.1.5:
   version "1.1.6"
@@ -2266,7 +2838,14 @@ string-width@^2.0.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^3.0.0"
 
-string_decoder@~1.0.0:
+string-width@^2.1.0, string-width@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
+  dependencies:
+    is-fullwidth-code-point "^2.0.0"
+    strip-ansi "^4.0.0"
+
+string_decoder@~1.0.0, string_decoder@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.3.tgz#0fc67d7c141825de94282dd536bec6b9bce860ab"
   dependencies:
@@ -2281,6 +2860,12 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
   dependencies:
     ansi-regex "^2.0.0"
+
+strip-ansi@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
+  dependencies:
+    ansi-regex "^3.0.0"
 
 strip-bom@^2.0.0:
   version "2.0.0"
@@ -2316,6 +2901,23 @@ supports-color@^3.1.0, supports-color@^3.1.2:
   dependencies:
     has-flag "^1.0.0"
 
+supports-color@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.3.0.tgz#5b24ac15db80fa927cf5227a4a33fd3c4c7676c0"
+  dependencies:
+    has-flag "^3.0.0"
+
+table@4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/table/-/table-4.0.2.tgz#a33447375391e766ad34d3486e6e2aedc84d2e36"
+  dependencies:
+    ajv "^5.2.3"
+    ajv-keywords "^2.1.0"
+    chalk "^2.1.0"
+    lodash "^4.17.4"
+    slice-ansi "1.0.0"
+    string-width "^2.1.1"
+
 tar-pack@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/tar-pack/-/tar-pack-3.4.0.tgz#23be2d7f671a8339376cbdb0b8fe3fdebf317984"
@@ -2347,9 +2949,27 @@ test-exclude@^4.1.1:
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
 
+text-table@~0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
+
+through@^2.3.6:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
+
+tmp@^0.0.33:
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
+  dependencies:
+    os-tmpdir "~1.0.2"
+
 to-fast-properties@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
+
+to-fast-properties@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
 
 tough-cookie@~2.3.0:
   version "2.3.2"
@@ -2384,6 +3004,10 @@ type-detect@0.1.1:
 type-detect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-1.0.0.tgz#762217cc06db258ec48908a1298e8b95121e8ea2"
+
+typedarray@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
 uglify-js@^2.6:
   version "2.8.22"
@@ -2483,6 +3107,12 @@ write-file-atomic@^1.1.4:
     graceful-fs "^4.1.11"
     imurmurhash "^0.1.4"
     slide "^1.1.5"
+
+write@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/write/-/write-0.2.1.tgz#5fc03828e264cea3fe91455476f7a3c566cb0757"
+  dependencies:
+    mkdirp "^0.5.1"
 
 y18n@^3.2.1:
   version "3.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1944,6 +1944,10 @@ qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
 
+ramda@^0.25.0:
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.25.0.tgz#8fdf68231cffa90bc2f9460390a0cb74a29b29a9"
+
 randomatic@^1.1.3:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.7.tgz#c7abe9cc8b87c0baa876b19fde83fd464797e38c"


### PR DESCRIPTION
Changes:
- Rework Result structure to be more AST-like so that we can customise printing
- Add a `printVerbose` function which mimics previous printing behaviour
- Update tests as necessary
- Add eslint (https://github.com/times/data-validator/issues/30)
- Add .prettierrc
- Introduce Ramda for functional goodness (https://github.com/times/data-validator/issues/9)
- Improve inline comments
- v0.6.0

Things to look for in particular during the review:
- Is everything still readable, etc? I changed quite a lot
- Does the new internal error structure make sense?
- I remove `prefixErrors` and `toResult`, which no longer worked well. Is that OK?